### PR TITLE
fix: resolution of mmdc binary

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -177,7 +177,7 @@ export default async (options: GeneratorOptions) => {
     );
 
     const mermaidCliNodePath = path.resolve(
-      path.join('node_modules', '.bin', 'mmdc')
+      path.join(__dirname, '../node_modules', '.bin', 'mmdc')
     );
 
     child_process.execSync(


### PR DESCRIPTION
In a scenario where `prisma-erd-generator` is not installed in the project root but any other directory (e.g. monorepo) the current implementation doesn't resolve the `mmdc` binary correctly.

## Example

Our project lives in `/Users/me/workspace1/my-project`

and we install `prisma-erd-generator` into it via e.g. `yarn workspace`. It will then live under `/Users/me/workspace1/node_modules/prisma-erd-generator`, hence the `mmdc` binary is now in `/Users/me/workspace1/node_modules/prisma-erd-generator/node_modules/.bin/mmdc`.

The current implementation always "statically" resolves to the current projects root `node_modules` meaning `/Users/me/workspace1/my-project/prisma-erd-generator/node_modules/.bin/mmdc`.

This PR makes sure the `mmdc` binary always get resolved properly.

Potentially related to #8 and #10 for some users (me included).