### PR TITLE
Fix: find mmdc binary universally

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -248,7 +248,7 @@ export default async (options: GeneratorOptions) => {
         );
 
         const mermaidCliNodePath = path.resolve(
-            path.join('node_modules', '.bin', 'mmdc')
+            child_process.execSync('find ../.. -name mmdc').toString().split('\n').filter(path => path).pop()
         );
 
         child_process.execSync(


### PR DESCRIPTION
I was having an issue with missing output svg - it turned out this was because of yarn workspaces installing mmdc in a different location.

I've tested this with yarn workspaces and pnpm workspaces on macOS.

This could be related to #28 