### PR TITLE
fix(windows): Add cross-env to `DISABLE_ERD=true` command to make Windows compatible

### DIFF
--- a/__tests__/disabled.ts
+++ b/__tests__/disabled.ts
@@ -5,7 +5,7 @@ test('dsiabled.prisma', async () => {
     const folderName = '__tests__';
     child_process.execSync(`rm -f ${folderName}/${fileName}`);
     child_process.execSync(
-        `DISABLE_ERD=true npx prisma generate --schema ./prisma/disabled.prisma`
+        `npx cross-env DISABLE_ERD=true npx prisma generate --schema ./prisma/disabled.prisma`
     );
     try {
         const listFile = child_process.execSync(


### PR DESCRIPTION
Not 100% sure about the repeating of `npx`, so let's see what the tests say.