### PR TITLE
bug fix Issue 138

### DIFF
--- a/__tests__/issues/138.test.ts
+++ b/__tests__/issues/138.test.ts
@@ -15,8 +15,10 @@ test('id not override before key name', async () => {
     expect(svgContent).toContain('UserSetting');
 
     // User has id
-    // expect(svgContent).toContain('id="entity-User-attr-1-name" class="er entityLabel">id</text>');
-    // // UserSetting has id and userId
+    expect(svgContent).toContain(
+        'id="entity-User-attr-1-name" class="er entityLabel">id</text>'
+    );
+    // UserSetting has id and userId
     // expect(svgContent).toContain('id="entity-UserSetting-attr-1-name" class="er entityLabel">id');
     // expect(svgContent).toContain('id="entity-UserSetting-attr-2-name" class="er entityLabel">user_id');
     // // UserSetting has a relation to User

--- a/__tests__/issues/138.test.ts
+++ b/__tests__/issues/138.test.ts
@@ -1,0 +1,24 @@
+import * as child_process from 'child_process';
+
+test('id not override before key name', async () => {
+    const fileName = '138.svg';
+    const folderName = '__tests__';
+    child_process.execSync(`rm -f ${folderName}/${fileName}`);
+    child_process.execSync(
+        `prisma generate --schema ./prisma/issues/138.prisma`
+    );
+    const svgContent = child_process
+        .execSync(`cat ${folderName}/${fileName}`)
+        .toString();
+    // did the model get added
+    expect(svgContent).toContain('User');
+    expect(svgContent).toContain('UserSetting');
+
+    // User has id
+    // expect(svgContent).toContain('id="entity-User-attr-1-name" class="er entityLabel">id</text>');
+    // // UserSetting has id and userId
+    // expect(svgContent).toContain('id="entity-UserSetting-attr-1-name" class="er entityLabel">id');
+    // expect(svgContent).toContain('id="entity-UserSetting-attr-2-name" class="er entityLabel">user_id');
+    // // UserSetting has a relation to User
+    // expect(svgContent).toContain('id="rel1" class="er relationshipLabel">user_id -> id');
+});

--- a/__tests__/issues/138.test.ts
+++ b/__tests__/issues/138.test.ts
@@ -19,8 +19,12 @@ test('id not override before key name', async () => {
         'id="entity-User-attr-1-name" class="er entityLabel">id</text>'
     );
     // UserSetting has id and userId
-    // expect(svgContent).toContain('id="entity-UserSetting-attr-1-name" class="er entityLabel">id');
-    // expect(svgContent).toContain('id="entity-UserSetting-attr-2-name" class="er entityLabel">user_id');
+    expect(svgContent).toContain(
+        'id="entity-UserSetting-attr-1-name" class="er entityLabel">id'
+    );
+    expect(svgContent).toContain(
+        'id="entity-UserSetting-attr-2-name" class="er entityLabel">user_id'
+    );
     // // UserSetting has a relation to User
-    // expect(svgContent).toContain('id="rel1" class="er relationshipLabel">user_id -> id');
+    expect(svgContent).toContain('id="rel1" class="er relationshipLabel">user');
 });

--- a/prisma/issues/138.prisma
+++ b/prisma/issues/138.prisma
@@ -1,0 +1,23 @@
+generator erd {
+    provider = "node ./dist/index.js"
+    output   = "../../__tests__/138.svg"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+model User {
+    id   Int    @id @default(autoincrement())
+    name String
+
+    userSettings UserSetting[]
+}
+
+model UserSetting {
+    id     Int @id @default(autoincrement())
+    userId Int @map("user_id")
+
+    user User @relation(fields: [userId], references: [id])
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -354,7 +354,6 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
 };
 
 export default async (options: GeneratorOptions) => {
-    console.log(options);
     try {
         const output = options.generator.output?.value || './prisma/ERD.svg';
         const config = options.generator.config;

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -308,27 +308,6 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
             ...model,
             fields: model.fields.map((field) => {
                 let filterStatus: 'None' | 'Match' | 'End' = 'None';
-                // console.log('field', field.name);
-                // console.log(
-                //     splitDataModel
-                //         // skip lines before the current model
-                //         .filter((line) => {
-                //             if (
-                //                 filterStatus === 'Match' &&
-                //                 line.includes('model ')
-                //             ) {
-                //                 filterStatus = 'End';
-                //             }
-                //             if (
-                //                 filterStatus === 'None' &&
-                //                 line.includes(`model ${model.name} `)
-                //             ) {
-                //                 filterStatus = 'Match';
-                //             }
-                //             return filterStatus === 'Match';
-                //         })
-                //         .find((line) => line.includes(`${field.name}`))
-                // );
                 // get line with field to \n
                 const lineInDataModel = splitDataModel
                     // filter the current model
@@ -356,9 +335,6 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
                     const regex = new RegExp(/@map\(\"(.*?)\"\)/, 'g');
                     const match = regex.exec(lineInDataModel);
 
-                    console.log(lineInDataModel);
-                    console.log('field', field.name);
-                    console.log('match', match);
                     if (match?.[1]) {
                         const name = match[1]
                             .replace(/^_/, 'z_') // replace leading underscores

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -307,14 +307,46 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
         return {
             ...model,
             fields: model.fields.map((field) => {
+                let filterStatus: 'None' | 'Match' | 'End' = 'None';
+                // console.log('field', field.name);
+                // console.log(
+                //     splitDataModel
+                //         // skip lines before the current model
+                //         .filter((line) => {
+                //             if (
+                //                 filterStatus === 'Match' &&
+                //                 line.includes('model ')
+                //             ) {
+                //                 filterStatus = 'End';
+                //             }
+                //             if (
+                //                 filterStatus === 'None' &&
+                //                 line.includes(`model ${model.name} `)
+                //             ) {
+                //                 filterStatus = 'Match';
+                //             }
+                //             return filterStatus === 'Match';
+                //         })
+                //         .find((line) => line.includes(`${field.name}`))
+                // );
                 // get line with field to \n
                 const lineInDataModel = splitDataModel
-                    // skip lines before the current model
-                    .slice(
-                        splitDataModel.findIndex((line) =>
-                            line.includes(`model ${model.name}`)
-                        )
-                    )
+                    // filter the current model
+                    .filter((line) => {
+                        if (
+                            filterStatus === 'Match' &&
+                            line.includes('model ')
+                        ) {
+                            filterStatus = 'End';
+                        }
+                        if (
+                            filterStatus === 'None' &&
+                            line.includes(`model ${model.name} `)
+                        ) {
+                            filterStatus = 'Match';
+                        }
+                        return filterStatus === 'Match';
+                    })
                     .find((line) => line.includes(`${field.name}`));
                 if (lineInDataModel) {
                     const regex = new RegExp(/@map\(\"(.*?)\"\)/, 'g');
@@ -339,6 +371,7 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
 };
 
 export default async (options: GeneratorOptions) => {
+    console.log(options);
     try {
         const output = options.generator.output?.value || './prisma/ERD.svg';
         const config = options.generator.config;

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -347,11 +347,18 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
                         }
                         return filterStatus === 'Match';
                     })
-                    .find((line) => line.includes(`${field.name}`));
+                    .find(
+                        (line) =>
+                            line.includes(`${field.name} `) &&
+                            line.includes('@map')
+                    );
                 if (lineInDataModel) {
                     const regex = new RegExp(/@map\(\"(.*?)\"\)/, 'g');
                     const match = regex.exec(lineInDataModel);
 
+                    console.log(lineInDataModel);
+                    console.log('field', field.name);
+                    console.log('match', match);
                     if (match?.[1]) {
                         const name = match[1]
                             .replace(/^_/, 'z_') // replace leading underscores


### PR DESCRIPTION
Sorry if it is hard to read as it is a tool translation.

## summary
https://github.com/keonik/prisma-erd-generator/issues/138

This is a fix for a bug reported in issue 138.

If a model UserSetting containing a map existed after a model User not containing a map
User's id field was being overwritten by UserSetting's map name.

There were two issues.
1. // skip lines before the current model 
  was including subsequent models in the decision
2. find matched any field containing "id" because it was a simple character search.

For issue 1, we fixed the problem so that only the current model is filtered.
For problem 2, we added `${field.name}` -> `${field.name} ` and a space to make it match more strictly.

## check
```
$ npm run test --t issues/138                                                                            

> prisma-erd-generator@1.2.3 test
> jest --passWithNoTests issues/138

 PASS  __tests__/issues/138.test.ts
  ✓ id not override before key name (2641 ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.978 s, estimated 3 s
Ran all test suites matching /issues\/138/i.
```

## result svg
![138](https://user-images.githubusercontent.com/46421953/201990093-fd46d366-9140-4582-b2bb-7596e8f31beb.svg)

We would appreciate your review.