### PR TITLE
fix: generator fails when path contains spaces

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -144,6 +144,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "maxijonson",
+      "name": "Tristan Chin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23557893?v=4",
+      "profile": "https://www.chintristan.io/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Prisma Entity Relationship Diagram Generator
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-15-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Prisma generator to create an ER Diagram every time you generate your prisma client.
@@ -219,6 +219,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/balzafin"><img src="https://avatars.githubusercontent.com/u/4311269?v=4?s=100" width="100px;" alt="Petri Julkunen"/><br /><sub><b>Petri Julkunen</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/issues?q=author%3Abalzafin" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/dznbk"><img src="https://avatars.githubusercontent.com/u/46421953?v=4?s=100" width="100px;" alt="D-PONTARO"/><br /><sub><b>D-PONTARO</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=dznbk" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/stephenramthun"><img src="https://avatars.githubusercontent.com/u/4243438?v=4?s=100" width="100px;" alt="Stephen Ramthun"/><br /><sub><b>Stephen Ramthun</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=stephenramthun" title="Documentation">📖</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.chintristan.io/"><img src="https://avatars.githubusercontent.com/u/23557893?v=4?s=100" width="100px;" alt="Tristan Chin"/><br /><sub><b>Tristan Chin</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=maxijonson" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -116,7 +116,7 @@ export async function parseDatamodel(
 
     const parsed: string = await new Promise((resolve, reject) => {
         const process = child_process.exec(
-            `${engine} --datamodel-path=${tmpSchema} cli dmmf`
+            `"${engine}" --datamodel-path="${tmpSchema}" cli dmmf`
         );
         let output = '';
         process.stderr?.on('data', (l) => {
@@ -479,7 +479,7 @@ export default async (options: GeneratorOptions) => {
             }
         }
 
-        const mermaidCommand = `${mermaidCliNodePath} -i ${tempMermaidFile} -o ${output} -t ${theme} -c ${tempConfigFile}`;
+        const mermaidCommand = `"${mermaidCliNodePath}" -i "${tempMermaidFile}" -o "${output}" -t ${theme} -c "${tempConfigFile}"`;
         if (debug && mermaidCommand)
             console.log('mermaid command: ', mermaidCommand);
         child_process.execSync(mermaidCommand, {


### PR DESCRIPTION
Fixes #113 

I had the issue myself and found the solution by editing the compiled .js files from the node_modules directory of my project. I wrapped everything that had file system paths in quotes (in both the `mermaidCommand` and `parseDatamodel` function) so that it is properly executed even when there are spaces in the directory path.

All (22) tests passed as well