### PR TITLE
introduce ignoreViews parameter

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -153,6 +153,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "hakandilek",
+      "name": "Hakan Dilek",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1072473?v=4",
+      "profile": "http://www.dilek.me/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 !__test__/*.ts
 __tests__/*.svg
 __tests__/*.png
+.idea

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Prisma Entity Relationship Diagram Generator
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-15-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Prisma generator to create an ER Diagram every time you generate your prisma client.
@@ -233,6 +233,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://www.chintristan.io/"><img src="https://avatars.githubusercontent.com/u/23557893?v=4?s=100" width="100px;" alt="Tristan Chin"/><br /><sub><b>Tristan Chin</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=maxijonson" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://www.dilek.me/"><img src="https://avatars.githubusercontent.com/u/1072473?v=4?s=100" width="100px;" alt="Hakan Dilek"/><br /><sub><b>Hakan Dilek</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=hakandilek" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ generator erd {
 }
 ```
 
+### Ignore views
+
+If you enable this option, view entities will be hidden.
+This is useful if you want to reduce the number of entities and focus on the tables without displaying all the views.
+
+```prisma
+generator erd {
+  provider = "prisma-erd-generator"
+  ignoreViews = true
+}
+```
 ### Include relation from field
 
 By default this module skips relation fields in the result diagram. For example fields `userId` and `productId` will not be generated from this prisma schema.

--- a/__tests__/ignoreViews.test.ts
+++ b/__tests__/ignoreViews.test.ts
@@ -1,0 +1,41 @@
+import * as child_process from 'child_process';
+
+test('ignore-views.prisma', async () => {
+    const fileName = 'ignoreViews.svg';
+    const folderName = '__tests__';
+    child_process.execSync(`rm -f ${folderName}/${fileName}`);
+    child_process.execSync(
+        `prisma generate --schema ./prisma/ignore-views.prisma`
+    );
+    const listFile = child_process.execSync(`ls -la ${folderName}/${fileName}`);
+    // did it generate a file
+    expect(listFile.toString()).toContain(fileName);
+
+    const svgAsString = child_process
+        .execSync(`cat ${folderName}/${fileName}`)
+        .toString();
+
+    // did it generate a file without enum
+    expect(svgAsString).toContain(`<svg`);
+    // include tables
+    expect(svgAsString).toContain(`Booking`);
+    expect(svgAsString).toContain(`Event`);
+    // include table columns
+    expect(svgAsString).toContain(`name`);
+    expect(svgAsString).toContain(`startDate`);
+    expect(svgAsString).toContain(`status`);
+    expect(svgAsString).toContain(`inviteeEmail`);
+    expect(svgAsString).toContain(`startDateUTC`);
+    expect(svgAsString).toContain(`cancelCode`);
+    // include enum names
+    expect(svgAsString).toContain(`Status`);
+    // include enums
+    expect(svgAsString).toContain(`PENDING`);
+    expect(svgAsString).toContain(`CONFIRMED`);
+    expect(svgAsString).toContain(`CANCELLED`);
+    // exclude views
+    expect(svgAsString).not.toContain(`Attendance`);
+    expect(svgAsString).not.toContain(`email`);
+    expect(svgAsString).not.toContain(`eventDate`);
+    expect(svgAsString).not.toContain(`bookingStatus`);
+});

--- a/prisma/ignore-views.prisma
+++ b/prisma/ignore-views.prisma
@@ -1,0 +1,44 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+generator erd {
+    provider        = "node ./dist/index.js"
+    output          = "../__tests__/ignoreViews.svg"
+    theme           = "forest"
+    previewFeatures = ["views"]
+    ignoreViews     = true
+}
+
+model Booking {
+    id           Int      @id @default(autoincrement())
+    inviteeEmail String
+    startDateUTC DateTime
+    cancelCode   String
+    events       Event[]
+}
+
+model Event {
+    id        Int       @id @default(autoincrement())
+    name      String
+    startDate DateTime
+    bookings  Booking[]
+    status    Status    @default(PENDING)
+}
+
+enum Status {
+    PENDING
+    CANCELLED
+    CONFIRMED
+}
+
+view Attendance {
+    id            Int      @unique
+    email         String
+    eventDate     DateTime
+    bookingStatus Status
+}


### PR DESCRIPTION
I just wanted to introduce an `ignoreViews` parameter just like the existing `ignoreEnums` using the preview `views` feature.

This is not complete and I'm kind of stuck and may need some help to bump this forward. The problem is that there's no significant identifier for `view`s in the DMMF model output generated by the model engine, there's no way to distinguish `view` from the regular table `model`s.