### PR TITLE
Update disable_erd condition

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -377,7 +377,7 @@ export default async (options: GeneratorOptions) => {
         const ignoreEnums = config.ignoreEnums === 'true';
         const includeRelationFromFields =
             config.includeRelationFromFields === 'true';
-        const disabled = Boolean(process.env.DISABLE_ERD);
+        const disabled = process.env.DISABLE_ERD === 'true';
         const debug =
             config.erdDebug === 'true' || Boolean(process.env.ERD_DEBUG);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { generatorHandler } from '@prisma/generator-helper';
 import generate from './generate';
 
-const disabled = Boolean(process.env.DISABLE_ERD);
+const disabled = process.env.DISABLE_ERD === 'true';
 
 generatorHandler({
     onManifest: () => ({


### PR DESCRIPTION
Boolean('false') in js returns true because a non-empty string is considered "truthy" in js.