### PR TITLE
Option to disable emoji output

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -180,6 +180,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "halostatue",
+      "name": "Austin Ziegler",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11361?v=4",
+      "profile": "https://github.com/halostatue",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Prisma Entity Relationship Diagram Generator
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-19-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Prisma generator to create an ER Diagram every time you generate your prisma client.
@@ -189,6 +189,17 @@ generator erd {
 }
 ```
 
+### Disable emoji output
+
+The emoji output for primary keys (`🗝️`) and nullable fields (`❓`) can be disabled, restoring the older values of `PK` and `nullable`, respectively.
+
+```prisma
+generator erd {
+  provider     = "prisma-erd-generator"
+  disableEmoji = true
+}
+```
+
 ### Puppeteer configuration
 
 If you want to change the configuration of Puppeteer, create a [Puppeteer config file (JSON)](https://pptr.dev/guides/configuration#configuration-files) and pass the file path to the generator.
@@ -265,6 +276,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/bcanfield"><img src="https://avatars.githubusercontent.com/u/12603953?v=4?s=100" width="100px;" alt="Brandin Canfield"/><br /><sub><b>Brandin Canfield</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=bcanfield" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://scrapbox.io/mrsekut-p/"><img src="https://avatars.githubusercontent.com/u/24796587?v=4?s=100" width="100px;" alt="kota marusue"/><br /><sub><b>kota marusue</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=mrsekut" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/shiralwz"><img src="https://avatars.githubusercontent.com/u/6162142?v=4?s=100" width="100px;" alt="Lucia"/><br /><sub><b>Lucia</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/issues?q=author%3Ashiralwz" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://www.halostatue.ca/"><img src="https://avatars.githubusercontent.com/u/11361?v=4?s=100" width="100px;" alt="Austin Ziegler"/><br /><sub><b>Austin Ziegler</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=halostatue" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/__tests__/disableEmoji.test.ts
+++ b/__tests__/disableEmoji.test.ts
@@ -1,0 +1,27 @@
+import * as child_process from 'child_process';
+
+test('disableEmoji.prisma', async () => {
+    const fileName = 'disableEmoji.svg';
+    const folderName = '__tests__';
+    child_process.execSync(`rm -f ${folderName}/${fileName}`);
+    child_process.execSync(
+        `prisma generate --schema ./prisma/disableEmoji.prisma`
+    );
+    const listFile = child_process.execSync(`ls -la ${folderName}/${fileName}`);
+    // did it generate a file
+    expect(listFile.toString()).toContain(fileName);
+
+    const svgAsString = child_process
+        .execSync(`cat ${folderName}/${fileName}`)
+        .toString();
+
+    // did it generate a file with the correct content
+    expect(svgAsString).toContain(`<svg`);
+    expect(svgAsString).not.toContain(`❓`);
+    expect(svgAsString).not.toContain(`🗝️`);
+    expect(svgAsString).toContain(`nullable`);
+    expect(svgAsString).toContain(`PK`);
+    expect(svgAsString).toContain(`inviteeEmail`);
+    expect(svgAsString).toContain(`cancelCode`);
+    expect(svgAsString).toContain(`name`);
+});

--- a/prisma/disableEmoji.prisma
+++ b/prisma/disableEmoji.prisma
@@ -1,0 +1,29 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+generator erd {
+    provider     = "node ./dist/index.js"
+    output       = "../__tests__/disableEmoji.svg"
+    theme        = "forest"
+    disableEmoji = true
+}
+
+model Booking {
+    id           Int      @id @default(autoincrement())
+    inviteeEmail String?
+    startDateUTC DateTime
+    cancelCode   String?
+    events       Event[]
+}
+
+model Event {
+    id        Int       @id @default(autoincrement())
+    name      String?
+    startDate DateTime
+    bookings  Booking[]
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -27,6 +27,7 @@ export interface DMLRendererOptions {
     tableOnly?: boolean;
     ignoreEnums?: boolean;
     includeRelationFromFields?: boolean;
+    disableEmoji?: boolean;
 }
 
 // Copy paste of the DMLModel
@@ -139,6 +140,7 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
         tableOnly = false,
         ignoreEnums = false,
         includeRelationFromFields = false,
+        disableEmoji = false,
     } = options ?? {};
 
     const diagram = 'erDiagram';
@@ -165,6 +167,8 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
                   )
                   .join('\n\n');
 
+    const pkSigil = disableEmoji ? '"PK"' : '"🗝️"';
+    const nullableSigil = disableEmoji ? '"nullable"' : '"❓"';
     const classes = modellikes
         .map(
             (model) =>
@@ -182,9 +186,9 @@ ${
                   )} ${
                       field.isId ||
                       model.primaryKey?.fields?.includes(field.name)
-                          ? '"🗝️"'
+                          ? pkSigil
                           : ''
-                  }${field.isRequired ? '' : '"❓"'}`;
+                  }${field.isRequired ? '' : nullableSigil}`;
               })
               .join('\n')
 }
@@ -366,6 +370,7 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
 
 export default async (options: GeneratorOptions) => {
     try {
+        console.log('generator options', options);
         const output = options.generator.output?.value || './prisma/ERD.svg';
         const config = options.generator.config;
 
@@ -374,6 +379,7 @@ export default async (options: GeneratorOptions) => {
             path.join(config.mmdcPath || 'node_modules/.bin', 'mmdc')
         );
         const tableOnly = config.tableOnly === 'true';
+        const disableEmoji = config.disableEmoji === 'true';
         const ignoreEnums = config.ignoreEnums === 'true';
         const includeRelationFromFields =
             config.includeRelationFromFields === 'true';
@@ -431,6 +437,7 @@ export default async (options: GeneratorOptions) => {
             tableOnly,
             ignoreEnums,
             includeRelationFromFields,
+            disableEmoji,
         });
         if (debug && mermaid) {
             const mermaidFile = path.resolve('prisma/debug/3-mermaid.mmd');


### PR DESCRIPTION
Resolves #226

Because the default would be to generate emoji output (so as to not result in a regression for those who prefer the emoji output), I have named the configuration `disableEmoji`. Setting `disableEmoji = true` reverts the generated code to `PK` and `nullable`.