### PR TITLE
Do not log options on generate

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -370,7 +370,6 @@ export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
 
 export default async (options: GeneratorOptions) => {
     try {
-        console.log('generator options', options);
         const output = options.generator.output?.value || './prisma/ERD.svg';
         const config = options.generator.config;
 


### PR DESCRIPTION
This seems to have been introduced here: https://github.com/keonik/prisma-erd-generator/pull/229. I assume it's not intentional?

Another option could be to conditionally log the options:

```ts
if (debug) {
  console.log('generator options', options);
}
```