### PR TITLE
Support for Deno runtime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,13 @@ const disabled = process.env.DISABLE_ERD === 'true'
 
 import { readFileSync } from 'fs';
 
-const packageJsonPath = 'package.json';
-const packageJsonData = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+let packageJsonData;
+try {
+    packageJsonData = JSON.parse(readFileSync('package.json', 'utf-8'));
+} catch (e) {
+    console.error(e);
+    packageJsonData = { version: "1.0.0" };
+}
 
 generatorHandler({
     onManifest: () => ({


### PR DESCRIPTION
Recently updated dependencies and noticed that `package.json` is required now for retrieving the project version info. This broke the ability to generate diagrams for Deno projects.

Proposed fix handles missing `package.json` file with a default value of `{ "version": "1.0.0" }` to prevent issues when using Prisma with Deno.