### PR TITLE
fix: resolve composite types by name and drop stray debug log

### DIFF
--- a/.changeset/fix-composite-type-noise.md
+++ b/.changeset/fix-composite-type-noise.md
@@ -1,0 +1,8 @@
+---
+"prisma-erd-generator": patch
+---
+
+Fix composite types and remove stray debug output.
+
+- Remove a leftover `console.log` that printed the resolved type object to the build console on every generate involving composite types (e.g. MongoDB embedded types).
+- Fix composite-type relationship resolution: the lookup never actually compared anything (the comparison was stranded inside a comment), so it always resolved to the first composite type in the schema. It now matches the related type by name, so schemas with multiple composite types render their relationships correctly.

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -181,9 +181,8 @@ ${
                     (model) =>
                         model.name
                             .replace(/^_/, 'z_') // replace leading underscores
-                            .replace(/\s/g, '') // remove spaces === otherSide
+                            .replace(/\s/g, '') === field.type // remove spaces
                 )
-                console.log(otherSide, otherSideCompositeType)
                 if (otherSideCompositeType) {
                     // most logic here is a copy/paste from the normal relation logic
                     // TODO extract and reuse


### PR DESCRIPTION
## Track A — "show a pulse" (1/2)

First of a couple of small, low-risk fixes to signal the project is active again.

### What & why
1. **Removed a stray `console.log`** in `renderDml` that dumped the resolved type object to the build console on *every* generate involving composite types (e.g. MongoDB embedded types). Pure noise in users' build output.
2. **Fixed composite-type relationship resolution.** The `dml.types.find(...)` predicate never actually compared anything — the intended `=== otherSide` was stranded inside a comment, so the callback always returned a truthy string and the lookup always resolved to the *first* composite type in the schema. It now matches the related type by name (`=== field.type`). Schemas with a single composite type were correct by luck; schemas with multiple composite types would wire relationships to the wrong type.

### Testing
- `compositeTypes` and `compositePk` tests pass on Prisma 7.
- Output is byte-identical for the single-composite-type case (existing test stays green); the fix only changes behavior when there are multiple composite types.
- Full local suite is otherwise green — the intermittent failures seen locally are a known cold-cache race between concurrent `pnpm dlx prisma@<v>` downloads, not related to this change (each test passes in isolation; CI on `main` is green).

A changeset is included (patch → 2.4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)