### PR TITLE
ci: publish via npm OIDC trusted publishing (no more NPM_TOKEN)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
-  packages: write
+  # id-token: write lets GitHub mint the short-lived OIDC token that npm
+  # trusted publishing exchanges for publish access — no NPM_TOKEN needed.
   id-token: write
 
 jobs:
@@ -20,19 +21,29 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+      # NOTE: deliberately no `registry-url` here. setup-node's registry-url
+      # writes an .npmrc with `_authToken=${NODE_AUTH_TOKEN}`, and npm prefers
+      # that (now empty) token over OIDC. Omitting it lets trusted publishing
+      # engage.
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
+
+      # npm trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships an
+      # older npm, so upgrade the global npm that `changeset publish` calls.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm run ci:publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NPM_TOKEN / NODE_AUTH_TOKEN on purpose: with none present and a
+          # trusted publisher configured on npmjs.com, npm authenticates via
+          # OIDC and publishes provenance automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,10 @@ jobs:
 
       # npm trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships an
       # older npm, so upgrade the global npm that `changeset publish` calls.
+      # Pin to the 11.x line rather than @latest so a future npm major can't
+      # change publish behavior out from under a release.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Create Release Pull Request or Publish
         id: changesets

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# Releasing
+
+Releases are automated with [Changesets](https://github.com/changesets/changesets) and
+published to npm via **OIDC trusted publishing** — there is no `NPM_TOKEN` secret to
+manage or rotate.
+
+## Day-to-day flow
+
+1. **Every PR that changes published behavior includes a changeset.** Run:
+
+   ```sh
+   pnpm changeset
+   ```
+
+   Pick the bump level (patch/minor/major) and write a human-readable summary —
+   this becomes the changelog entry users read.
+
+2. **Merging changesets to `main`** triggers the `Publish` workflow, which opens (or
+   updates) a **"Version Packages"** PR. That PR bumps the version and updates
+   `CHANGELOG.md`.
+
+3. **Merging the "Version Packages" PR** publishes the new version to npm
+   automatically. That's the whole release — no manual `npm publish`.
+
+## Why there's no npm token
+
+The `Publish` workflow (`.github/workflows/publish.yml`) authenticates to npm using
+GitHub Actions **OIDC** rather than a long-lived token. This requires:
+
+- `permissions: id-token: write` in the workflow (present).
+- npm `>= 11.5.1` (the workflow upgrades npm before publishing).
+- **No** `_authToken` in any `.npmrc` — so the workflow intentionally omits
+  `setup-node`'s `registry-url` and passes no `NPM_TOKEN`/`NODE_AUTH_TOKEN`. If a token
+  is present, npm uses it instead of OIDC.
+- A **trusted publisher** configured on npmjs.com for this package:
+  - npm → package → **Settings** → **Trusted Publisher** → **GitHub Actions**
+  - Repository: `keonik/prisma-erd-generator`
+  - Workflow filename: `publish.yml`
+
+Provenance attestations are published automatically under trusted publishing.
+
+## Historical note
+
+This project previously also had `standard-version` wired up. It only bumped the
+version and tagged locally — it never published to npm — which is why `2.4.0` and
+`2.4.1` exist as tags/commits but were never released. It has been removed; changesets
+is the single source of truth for releases.


### PR DESCRIPTION
## Why

The 2.4.3 publish failed with a `404 PUT` from npm — the classic signature of an **expired/invalid `NPM_TOKEN`** (last publish was December; npm tokens expire). Rather than rotate a token that will expire again, this switches to **npm [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC)** — the current standard. No token to store, rotate, or leak; provenance is automatic.

## What changed in `publish.yml`

- **Removed** `NPM_TOKEN` / `NODE_AUTH_TOKEN` from the changesets step.
- **Removed** `setup-node`'s `registry-url` — it writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, and npm prefers that (now-empty) token over OIDC. Omitting it is required for OIDC to engage.
- **Added** `npm install -g npm@latest` — OIDC trusted publishing needs npm `>= 11.5.1`, and Node 22 ships an older npm. `changeset publish` shells out to this npm.
- **Removed** the unused `packages: write` permission. `id-token: write` (already present) is the one that matters.
- **Added** `RELEASING.md` documenting the flow and *why there's no token*.

## ⚠️ Required before this can publish — npmjs.com setup (only you can do this)

On npm: **package → Settings → Trusted Publisher → GitHub Actions**, then:
- Repository: `keonik/prisma-erd-generator`
- Workflow filename: `publish.yml`

## Suggested merge order
1. Configure the trusted publisher on npm (above).
2. Merge this PR. The merge pushes to `main`, which triggers `Publish`; since `2.4.3` is already version-bumped on `main` but unpublished, that run will publish `2.4.3` via OIDC.
3. (Optional) delete the now-dead `NPM_TOKEN` repo secret.

I'll watch the run and confirm `2.4.3` lands on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)