### PR TITLE
Add sortFields generator option

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -239,6 +239,15 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "anubhabx",
+      "name": "Anubhab Debnath",
+      "avatar_url": "https://avatars.githubusercontent.com/u/84611567?v=4",
+      "profile": "https://www.anubhabx.me/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Prisma Entity Relationship Diagram Generator
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-23-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-25-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Prisma generator to create an ER Diagram every time you generate your prisma client.
@@ -256,6 +256,17 @@ generator erd {
 }
 ```
 
+### Sort fields
+
+Sort the fields inside each generated model alphabetically. This is disabled by default, so existing diagrams keep their current field order unless you opt in.
+
+```prisma
+generator erd {
+  provider   = "prisma-erd-generator"
+  sortFields = true
+}
+```
+
 ### Disable emoji output
 
 The emoji output for primary keys (`🗝️`) and nullable fields (`❓`) can be disabled, restoring the older values of `PK` and `nullable`, respectively.
@@ -368,7 +379,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://fabs.dev"><img src="https://avatars.githubusercontent.com/u/16561284?v=4?s=100" width="100px;" alt="Ian Fabs"/><br /><sub><b>Ian Fabs</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=ianfabs" title="Code">💻</a> <a href="https://github.com/keonik/prisma-erd-generator/issues?q=author%3Aianfabs" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://grmlfolio.vercel.app/"><img src="https://avatars.githubusercontent.com/u/209283286?v=4?s=100" width="100px;" alt="grMLEqomlkkU5Eeinz4brIrOVCUCkJuN"/><br /><sub><b>grMLEqomlkkU5Eeinz4brIrOVCUCkJuN</b></sub></a><br /><a href="#platform-grMLEqomlkkU5Eeinz4brIrOVCUCkJuN" title="Packaging/porting to new platform">📦</a> <a href="https://github.com/keonik/prisma-erd-generator/commits?author=grMLEqomlkkU5Eeinz4brIrOVCUCkJuN" title="Code">💻</a> <a href="https://github.com/keonik/prisma-erd-generator/commits?author=grMLEqomlkkU5Eeinz4brIrOVCUCkJuN" title="Tests">⚠️</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://soju.is/best"><img src="https://avatars.githubusercontent.com/u/34199905?v=4?s=100" width="100px;" alt="Soju06"/><br /><sub><b>Soju06</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=Soju06" title="Code">💻</a> <a href="#platform-Soju06" title="Packaging/porting to new platform">📦</a> <a href="#maintenance-Soju06" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://grmlfolio.vercel.app/"><img src="https://avatars.githubusercontent.com/u/209283286?v=4?s=100" width="100px;" alt="grMLEqomlkkU5Eeinz4brIrOVCUCkJuN"/><br /><sub><b>grMLEqomlkkU5Eeinz4brIrOVCUCkJuN</b></sub></a><br /><a href="#platform-grMLEqomlkkU5Eeinz4brIrOVCUCkJuN" title="Packaging/porting to new platform">📦</a> <a href="https://github.com/keonik/prisma-erd-generator/commits?author=grMLEqomlkkU5Eeinz4brIrOVCUCkJuN" title="Code">💻</a> <a href="https://github.com/keonik/prisma-erd-generator/commits?author=grMLEqomlkkU5Eeinz4brIrOVCUCkJuN" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.anubhabx.me/"><img src="https://avatars.githubusercontent.com/u/84611567?v=4?s=100" width="100px;" alt="Anubhab Debnath"/><br /><sub><b>Anubhab Debnath</b></sub></a><br /><a href="https://github.com/keonik/prisma-erd-generator/commits?author=anubhabx" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/__tests__/sortFields.test.ts
+++ b/__tests__/sortFields.test.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { GeneratorOptions } from "@prisma/generator-helper";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import generate from "../src/generate";
+
+const tmpDir = path.join(__dirname, "tmp-sort-fields");
+
+const datamodel = `
+model User {
+  zeta   String
+  alpha  String
+  id     Int    @id
+  middle String
+}
+`;
+
+const dmmfDatamodel = {
+  enums: [],
+  types: [],
+  models: [
+    {
+      name: "User",
+      dbName: "User",
+      fields: [
+        {
+          name: "zeta",
+          hasDefaultValue: false,
+          isGenerated: false,
+          isId: false,
+          isList: false,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+          isUpdatedAt: false,
+          kind: "scalar",
+          type: "String"
+        },
+        {
+          name: "alpha",
+          hasDefaultValue: false,
+          isGenerated: false,
+          isId: false,
+          isList: false,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+          isUpdatedAt: false,
+          kind: "scalar",
+          type: "String"
+        },
+        {
+          name: "id",
+          hasDefaultValue: false,
+          isGenerated: false,
+          isId: true,
+          isList: false,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+          isUpdatedAt: false,
+          kind: "scalar",
+          type: "Int"
+        },
+        {
+          name: "middle",
+          hasDefaultValue: false,
+          isGenerated: false,
+          isId: false,
+          isList: false,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+          isUpdatedAt: false,
+          kind: "scalar",
+          type: "String"
+        }
+      ],
+      idFields: [],
+      uniqueFields: [],
+      uniqueIndexes: [],
+      isGenerated: false,
+      primaryKey: {
+        name: null,
+        fields: ["id"]
+      }
+    }
+  ]
+};
+
+const baseGenerator = {
+  name: "erd",
+  provider: { fromEnvVar: null, value: "prisma-erd-generator" },
+  output: { fromEnvVar: null, value: "" },
+  config: {
+    disableEmoji: "true"
+  },
+  binaryTargets: [],
+  previewFeatures: [],
+  sourceFilePath: "schema.prisma"
+};
+
+const render = async (
+  fileName: string,
+  config: Record<string, string> = {}
+) => {
+  const outputFile = path.join(tmpDir, fileName);
+
+  await generate({
+    generator: {
+      ...baseGenerator,
+      output: { fromEnvVar: null, value: outputFile },
+      config: {
+        ...baseGenerator.config,
+        ...config
+      }
+    },
+    otherGenerators: [],
+    schemaPath: "schema.prisma",
+    dmmf: { datamodel: dmmfDatamodel },
+    datasources: [],
+    datamodel,
+    version: "test"
+  } as unknown as GeneratorOptions);
+
+  return fs.readFileSync(outputFile, "utf8");
+};
+
+describe("sortFields", () => {
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("preserves source field order by default", async () => {
+    const output = await render("default.md");
+
+    expect(output.indexOf("String zeta")).toBeLessThan(
+      output.indexOf("String alpha")
+    );
+    expect(output.indexOf("String alpha")).toBeLessThan(
+      output.indexOf("Int id")
+    );
+    expect(output.indexOf("Int id")).toBeLessThan(
+      output.indexOf("String middle")
+    );
+  });
+
+  it("sorts fields alphabetically when enabled", async () => {
+    const output = await render("sorted.md", { sortFields: "true" });
+
+    expect(output.indexOf("String alpha")).toBeLessThan(
+      output.indexOf("Int id")
+    );
+    expect(output.indexOf("Int id")).toBeLessThan(
+      output.indexOf("String middle")
+    );
+    expect(output.indexOf("String middle")).toBeLessThan(
+      output.indexOf("String zeta")
+    );
+  });
+
+  it("does not mutate the source field order when sorting", async () => {
+    await render("sorted.md", { sortFields: "true" });
+
+    const output = await render("default-after-sorted.md");
+
+    expect(output.indexOf("String zeta")).toBeLessThan(
+      output.indexOf("String alpha")
+    );
+    expect(output.indexOf("String alpha")).toBeLessThan(
+      output.indexOf("Int id")
+    );
+    expect(output.indexOf("Int id")).toBeLessThan(
+      output.indexOf("String middle")
+    );
+  });
+});

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -26,6 +26,7 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
         ignorePattern = [],
         includeRelationFromFields = false,
         disableEmoji = false,
+        sortFields = false,
     } = options ?? {}
 
     const diagram = 'erDiagram'
@@ -66,6 +67,15 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
 
     const pkSigil = disableEmoji ? '"PK"' : '"🗝️"'
     const nullableSigil = disableEmoji ? '"nullable"' : '"❓"'
+    const getShownFields = (model: DMLModel) => {
+        const fields = model.fields.filter(
+            isFieldShownInSchema(model, includeRelationFromFields)
+        )
+
+        return sortFields
+            ? fields.sort((a, b) => a.name.localeCompare(b.name))
+            : fields
+    }
     const classes = modellikes
         .map(
             (model) =>
@@ -73,8 +83,7 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
 ${
     tableOnly
         ? ''
-        : model.fields
-              .filter(isFieldShownInSchema(model, includeRelationFromFields))
+        : getShownFields(model)
               // the replace is a hack to make MongoDB style ID columns like _id valid for Mermaid
               .map((field) => {
                   return `    ${field.type.trimStart()} ${field.name.replace(
@@ -352,6 +361,7 @@ export default async (options: GeneratorOptions) => {
             : []
         const includeRelationFromFields =
             config.includeRelationFromFields === 'true'
+        const sortFields = config.sortFields === 'true'
         const disabled =
             process.env.DISABLE_ERD === 'true' || config.disabled === 'true'
         const debug =
@@ -412,6 +422,7 @@ export default async (options: GeneratorOptions) => {
             ignorePattern,
             includeRelationFromFields,
             disableEmoji,
+            sortFields,
         })
         if (debug && mermaid) {
             const mermaidFile = path.resolve('prisma/debug/3-mermaid.mmd')

--- a/types/dml.ts
+++ b/types/dml.ts
@@ -20,6 +20,7 @@ export interface DMLRendererOptions {
     ignorePattern?: string[]
     includeRelationFromFields?: boolean
     disableEmoji?: boolean
+    sortFields?: boolean
 }
 
 // Copy paste of the DMLModel

--- a/types/generator.ts
+++ b/types/generator.ts
@@ -7,6 +7,7 @@ export interface PrismaERDConfig {
     ignoreViews?: string
     ignorePattern?: string
     includeRelationFromFields?: string
+    sortFields?: string
     erdDebug?: string
     puppeteerConfig?: string
     mermaidConfig?: string


### PR DESCRIPTION
Closes #122 

## Overview

Adds an opt-in `sortFields` generator option that renders fields inside each model alphabetically while preserving the current source-order default.

## What changed

- Parses `sortFields = true` from generator config and passes it through renderer options.
- Sorts only the filtered display fields, without mutating the source DMMF/model field order.
- Documents the new option in the README.
- Adds a changeset.
- Adds DMMF-based regression coverage for default order, sorted order, and no mutation after a sorted render.

## Verification

- `pnpm exec vitest --config vitest.config.mts __tests__/sortFields.test.ts __tests__/dmmfInput.test.ts --run` — passed
- `pnpm build` via Git Bash — passed
- `pnpm exec vitest --config vitest.config.mts --run --maxWorkers=1 --fileParallelism=false` via Git Bash — passed
- `git diff --check` — passed