### PR TITLE
fix: read field-level @map from field.dbName instead of substring matching

### DIFF
--- a/.changeset/map-field-dbname.md
+++ b/.changeset/map-field-dbname.md
@@ -1,0 +1,8 @@
+---
+"prisma-erd-generator": patch
+---
+
+Fix field-level `@map` being applied to the wrong field.
+
+- A field whose name is a suffix of another field that has `@map` (e.g. `id` next to `user_id`) could be renamed to the other field's mapped column name, because the mapped value was recovered by substring-matching the raw schema text.
+- The mapped name is now read directly from the DMMF (`field.dbName`), the same way the model-level `@@map` is read from `model.dbName`, which removes the substring-collision class of bugs.

--- a/__tests__/dmmfInput.test.ts
+++ b/__tests__/dmmfInput.test.ts
@@ -23,6 +23,7 @@ const dmmfDatamodel = {
             fields: [
                 {
                     name: 'id',
+                    dbName: 'user_id',
                     hasDefaultValue: true,
                     isGenerated: false,
                     isId: true,

--- a/__tests__/map.test.ts
+++ b/__tests__/map.test.ts
@@ -4,10 +4,6 @@ import * as child_process from 'node:child_process';
 import { test, expect } from 'vitest';
 
 test('@map', async () => {
-    const model = `model User {
-      id              Int                 @id @default(autoincrement())
-      hashedPassword  String?             @map("hashed_password")
-    }`
     const dmlModels: DMLModel[] = [
         {
             dbName: null,
@@ -28,7 +24,8 @@ test('@map', async () => {
                     isUpdatedAt: false,
                 },
                 {
-                    name: 'hashed_password',
+                    name: 'hashedPassword',
+                    dbName: 'hashed_password',
                     kind: 'scalar',
                     isList: false,
                     isRequired: false,
@@ -44,7 +41,7 @@ test('@map', async () => {
         },
     ]
 
-    const mapTest = mapPrismaToDb(dmlModels, model)
+    const mapTest = mapPrismaToDb(dmlModels)
 
     expect(mapTest).toEqual([
         {
@@ -67,6 +64,7 @@ test('@map', async () => {
                 },
                 {
                     name: 'hashed_password',
+                    dbName: 'hashed_password',
                     kind: 'scalar',
                     isList: false,
                     isRequired: false,
@@ -74,6 +72,85 @@ test('@map', async () => {
                     isId: false,
                     isReadOnly: false,
                     type: 'String',
+                    hasDefaultValue: false,
+                    isGenerated: false,
+                    isUpdatedAt: false,
+                },
+            ],
+        },
+    ])
+})
+
+test('@map does not rename a field whose name is a suffix of another field', async () => {
+    // Regression for #288: `id` must not pick up the @map value of `user_id`.
+    const dmlModels: DMLModel[] = [
+        {
+            dbName: null,
+            name: 'Post',
+            fields: [
+                {
+                    name: 'id',
+                    kind: 'scalar',
+                    isList: false,
+                    isRequired: true,
+                    isUnique: false,
+                    isId: true,
+                    isReadOnly: false,
+                    type: 'Int',
+                    hasDefaultValue: true,
+                    default: { name: 'autoincrement', args: [] },
+                    isGenerated: false,
+                    isUpdatedAt: false,
+                },
+                {
+                    name: 'user_id',
+                    dbName: 'fk_user',
+                    kind: 'scalar',
+                    isList: false,
+                    isRequired: true,
+                    isUnique: false,
+                    isId: false,
+                    isReadOnly: false,
+                    type: 'Int',
+                    hasDefaultValue: false,
+                    isGenerated: false,
+                    isUpdatedAt: false,
+                },
+            ],
+        },
+    ]
+
+    const mapped = mapPrismaToDb(dmlModels)
+
+    expect(mapped).toEqual([
+        {
+            dbName: null,
+            name: 'Post',
+            fields: [
+                {
+                    name: 'id',
+                    kind: 'scalar',
+                    isList: false,
+                    isRequired: true,
+                    isUnique: false,
+                    isId: true,
+                    isReadOnly: false,
+                    type: 'Int',
+                    hasDefaultValue: true,
+                    default: { name: 'autoincrement', args: [] },
+                    isGenerated: false,
+                    isUpdatedAt: false,
+                },
+                {
+                    name: 'fk_user',
+                    dbName: 'fk_user',
+                    kind: 'scalar',
+                    isList: false,
+                    isRequired: true,
+                    isUnique: false,
+                    isId: false,
+                    isReadOnly: false,
+                    type: 'Int',
                     hasDefaultValue: false,
                     isGenerated: false,
                     isUpdatedAt: false,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -280,51 +280,15 @@ export const matchesIgnorePattern = (
     })
 }
 
-export const mapPrismaToDb = (dmlModels: DMLModel[], dataModel: string) => {
-    const splitDataModel = dataModel
-        ?.split('\n')
-        .filter((line) => line.includes('@map') || line.includes('model '))
-        .map((line) => line.trim())
-
+export const mapPrismaToDb = (dmlModels: DMLModel[]) => {
     return dmlModels.map((model) => {
         return {
             ...model,
             fields: model.fields.map((field) => {
-                let filterStatus: 'None' | 'Match' | 'End' = 'None'
-                // get line with field to \n
-                const lineInDataModel = splitDataModel
-                    // filter the current model
-                    .filter((line) => {
-                        if (
-                            filterStatus === 'Match' &&
-                            line.includes('model ')
-                        ) {
-                            filterStatus = 'End'
-                        }
-                        if (
-                            filterStatus === 'None' &&
-                            line.includes(`model ${model.name} `)
-                        ) {
-                            filterStatus = 'Match'
-                        }
-                        return filterStatus === 'Match'
-                    })
-                    .find(
-                        (line) =>
-                            line.includes(`${field.name} `) &&
-                            line.includes('@map')
-                    )
-                if (lineInDataModel) {
-                    const regex = new RegExp(/@map\(\"(.*?)\"\)/, 'g')
-                    const match = regex.exec(lineInDataModel)
-
-                    if (match?.[1]) {
-                        const name = match[1]
-                            .replace(/^_/, 'z_') // replace leading underscores
-                            .replace(/\s/g, '') // remove spaces
-
-                        field.name = name
-                    }
+                if (field.dbName) {
+                    field.name = field.dbName
+                        .replace(/^_/, 'z_') // replace leading underscores
+                        .replace(/\s/g, '') // remove spaces
                 }
 
                 return field
@@ -386,7 +350,7 @@ export default async (options: GeneratorOptions) => {
         }
 
         // updating dml to map to db table and column names (@map && @@map)
-        dml.models = mapPrismaToDb(dml.models, options.datamodel)
+        dml.models = mapPrismaToDb(dml.models)
 
         // default types to empty array
         if (!dml.types) {

--- a/types/dml.ts
+++ b/types/dml.ts
@@ -41,6 +41,7 @@ export interface DMLType {
 
 export interface DMLField {
     name: string
+    dbName?: string | null
     hasDefaultValue: boolean
     isGenerated: boolean
     isId: boolean


### PR DESCRIPTION
Closes #288.

`mapPrismaToDb` figured out a field's `@map` name by substring-matching the raw schema text, so a short field name like `id` matched inside a longer one like `user_id` and got renamed to the wrong column. #149 only papered over it with a trailing space.

`field.dbName` already holds the `@map` value (same as `model.dbName` does for `@@map`), so this reads it directly and drops the schema parsing. It's been on the DMMF since Prisma 4.9 (prisma/prisma-engines#3532). Normal output is unchanged. 

Added a regression test and reworked the existing `@map` test to go through `field.dbName`.

### AI Disclaimer
This PR was developed with the assistance of Claude. I've reviewed and verified the changes.