### PR TITLE
feat: add `includeComments` option to render `///` schema comments

### DIFF
--- a/.changeset/tidy-comments-render.md
+++ b/.changeset/tidy-comments-render.md
@@ -1,0 +1,5 @@
+---
+'prisma-erd-generator': minor
+---
+
+Add `includeComments` generator option to render `///` schema documentation comments as mermaid attribute comments (#248)

--- a/README.md
+++ b/README.md
@@ -267,6 +267,39 @@ generator erd {
 }
 ```
 
+### Include schema comments
+
+Render `///` documentation comments from your schema as mermaid attribute comments. Disabled by default.
+
+```prisma
+generator erd {
+  provider        = "prisma-erd-generator"
+  includeComments = true
+}
+```
+
+```prisma
+model Article {
+  /// Primary key
+  id    String  @id
+  /// Page title
+  title String
+  /// Page body
+  body  String?
+}
+```
+
+```mermaid
+erDiagram
+  "Article" {
+    String id "🗝️ Primary key"
+    String title "Page title"
+    String body "❓ Page body"
+  }
+```
+
+Only `///` comments are available — plain `//` comments are dropped by Prisma before the generator runs. Comments share the attribute slot with the primary key and nullable sigils, and are flattened to a single line with `"` replaced by `'` so mermaid can parse them.
+
 ### Disable emoji output
 
 The emoji output for primary keys (`🗝️`) and nullable fields (`❓`) can be disabled, restoring the older values of `PK` and `nullable`, respectively.

--- a/__tests__/includeComments.test.ts
+++ b/__tests__/includeComments.test.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { GeneratorOptions } from '@prisma/generator-helper'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import generate from '../src/generate'
+
+const tmpDir = path.join(__dirname, 'tmp-include-comments')
+
+const datamodel = `
+/// An article
+model Article {
+  /// Primary key
+  id    String  @id
+  /// Page title
+  title String
+  /// Page "content"
+  /// spanning lines
+  body  String?
+  plain String
+}
+`
+
+const field = (name: string, overrides: Record<string, unknown> = {}) => ({
+    name,
+    hasDefaultValue: false,
+    isGenerated: false,
+    isId: false,
+    isList: false,
+    isReadOnly: false,
+    isRequired: true,
+    isUnique: false,
+    isUpdatedAt: false,
+    kind: 'scalar',
+    type: 'String',
+    ...overrides,
+})
+
+const dmmfDatamodel = {
+    enums: [],
+    types: [],
+    models: [
+        {
+            name: 'Article',
+            dbName: null,
+            documentation: 'An article',
+            fields: [
+                field('id', { isId: true, documentation: 'Primary key' }),
+                field('title', { documentation: 'Page title' }),
+                field('body', {
+                    isRequired: false,
+                    documentation: 'Page "content"\nspanning lines',
+                }),
+                field('plain'),
+            ],
+            idFields: [],
+            uniqueFields: [],
+            uniqueIndexes: [],
+            isGenerated: false,
+            primaryKey: null,
+        },
+    ],
+}
+
+const render = async (
+    fileName: string,
+    config: Record<string, string> = {}
+) => {
+    const outputFile = path.join(tmpDir, fileName)
+
+    await generate({
+        generator: {
+            name: 'erd',
+            provider: { fromEnvVar: null, value: 'prisma-erd-generator' },
+            output: { fromEnvVar: null, value: outputFile },
+            config,
+            binaryTargets: [],
+            previewFeatures: [],
+            sourceFilePath: 'schema.prisma',
+        },
+        otherGenerators: [],
+        schemaPath: 'schema.prisma',
+        dmmf: { datamodel: dmmfDatamodel },
+        datasources: [],
+        datamodel,
+        version: 'test',
+    } as unknown as GeneratorOptions)
+
+    return fs.readFileSync(outputFile, 'utf8')
+}
+
+describe('includeComments', () => {
+    beforeEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+        fs.mkdirSync(tmpDir, { recursive: true })
+    })
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('omits documentation by default', async () => {
+        const output = await render('default.md')
+
+        expect(output).toContain('String id "🗝️"')
+        expect(output).not.toContain('Primary key')
+    })
+
+    it('renders documentation alongside the key and nullable sigils', async () => {
+        const output = await render('comments.md', { includeComments: 'true' })
+
+        expect(output).toContain('String id "🗝️ Primary key"')
+        expect(output).toContain('String title "Page title"')
+        expect(output).toContain('String plain \n')
+    })
+
+    it('flattens quotes and line breaks so mermaid can parse the comment', async () => {
+        const output = await render('multiline.md', { includeComments: 'true' })
+
+        expect(output).toContain(
+            'String body "❓ Page \'content\' spanning lines"'
+        )
+    })
+
+    it('uses the non-emoji sigils when disableEmoji is set', async () => {
+        const output = await render('no-emoji.md', {
+            includeComments: 'true',
+            disableEmoji: 'true',
+        })
+
+        expect(output).toContain('String id "PK Primary key"')
+        expect(output).toContain(
+            'String body "nullable Page \'content\' spanning lines"'
+        )
+    })
+})

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -18,6 +18,11 @@ import type { MermaidConfig } from 'mermaid'
 
 dotenv.config() // Load the environment variables
 
+// Mermaid attribute comments are double-quoted single-line strings, so a `///`
+// comment has to lose its own quotes and line breaks to survive the round trip.
+const sanitizeComment = (comment: string) =>
+    comment.replace(/"/g, "'").replace(/\s+/g, ' ').trim()
+
 function renderDml(dml: DML, options?: DMLRendererOptions) {
     const {
         tableOnly = false,
@@ -27,6 +32,7 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
         includeRelationFromFields = false,
         disableEmoji = false,
         sortFields = false,
+        includeComments = false,
     } = options ?? {}
 
     const diagram = 'erDiagram'
@@ -65,8 +71,8 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
                   )
                   .join('\n\n')
 
-    const pkSigil = disableEmoji ? '"PK"' : '"🗝️"'
-    const nullableSigil = disableEmoji ? '"nullable"' : '"❓"'
+    const pkSigil = disableEmoji ? 'PK' : '🗝️'
+    const nullableSigil = disableEmoji ? 'nullable' : '❓'
     const getShownFields = (model: DMLModel) => {
         const fields = model.fields.filter(
             isFieldShownInSchema(model, includeRelationFromFields)
@@ -86,15 +92,24 @@ ${
         : getShownFields(model)
               // the replace is a hack to make MongoDB style ID columns like _id valid for Mermaid
               .map((field) => {
+                  const notes = []
+                  if (
+                      field.isId ||
+                      model.primaryKey?.fields?.includes(field.name)
+                  ) {
+                      notes.push(pkSigil)
+                  }
+                  if (!field.isRequired) {
+                      notes.push(nullableSigil)
+                  }
+                  if (includeComments && field.documentation) {
+                      notes.push(sanitizeComment(field.documentation))
+                  }
+
                   return `    ${field.type.trimStart()} ${field.name.replace(
                       /^_/,
                       'z_'
-                  )} ${
-                      field.isId ||
-                      model.primaryKey?.fields?.includes(field.name)
-                          ? pkSigil
-                          : ''
-                  }${field.isRequired ? '' : nullableSigil}`
+                  )} ${notes.length ? `"${notes.join(' ')}"` : ''}`
               })
               .join('\n')
 }
@@ -326,6 +341,7 @@ export default async (options: GeneratorOptions) => {
         const includeRelationFromFields =
             config.includeRelationFromFields === 'true'
         const sortFields = config.sortFields === 'true'
+        const includeComments = config.includeComments === 'true'
         const disabled =
             process.env.DISABLE_ERD === 'true' || config.disabled === 'true'
         const debug =
@@ -387,6 +403,7 @@ export default async (options: GeneratorOptions) => {
             includeRelationFromFields,
             disableEmoji,
             sortFields,
+            includeComments,
         })
         if (debug && mermaid) {
             const mermaidFile = path.resolve('prisma/debug/3-mermaid.mmd')

--- a/types/dml.ts
+++ b/types/dml.ts
@@ -21,6 +21,7 @@ export interface DMLRendererOptions {
     includeRelationFromFields?: boolean
     disableEmoji?: boolean
     sortFields?: boolean
+    includeComments?: boolean
 }
 
 // Copy paste of the DMLModel
@@ -58,6 +59,8 @@ export interface DMLField {
     relationOnDelete?: string
     relationToFields?: unknown[]
     default?: unknown
+    /** `/// comment` above the field in the prisma schema */
+    documentation?: string
 }
 
 export interface DMLEnum {

--- a/types/generator.ts
+++ b/types/generator.ts
@@ -8,6 +8,7 @@ export interface PrismaERDConfig {
     ignorePattern?: string
     includeRelationFromFields?: string
     sortFields?: string
+    includeComments?: string
     erdDebug?: string
     puppeteerConfig?: string
     mermaidConfig?: string


### PR DESCRIPTION
Closes #248

## What

Adds an opt-in `includeComments` generator option that renders `///` documentation comments from the Prisma schema as mermaid attribute comments.

```prisma
generator erd {
  provider        = "prisma-erd-generator"
  includeComments = true
}

model Article {
  /// Primary key
  id    String  @id
  /// Page title
  title String
  /// Page body
  body  String?
}
```

```mermaid
erDiagram
  "Article" {
    String id "🗝️ Primary key"
    String title "Page title"
    String body "❓ Page body"
  }
```

## How

Prisma already puts `///` comments on the DMMF as `field.documentation`, so no schema parsing is needed.

The one non-obvious bit: the PK/nullable sigils were previously emitted as *pre-quoted* strings (`'"PK"'`), which occupies the same mermaid attribute slot a comment would use — a field could never show both. They are now plain values collected into a `notes` array and quoted once at the end. Since a primary key is always required, PK and nullable can never co-occur, so **output is byte-identical when the option is off**.

Comments are flattened to one line and `"` is replaced with `'`, because mermaid attribute comments are single-line double-quoted strings.

## Not included

- Model-level `///` comments — mermaid's ER syntax has no entity comment slot. Noted in the README.
- `//` comments — Prisma drops those before the generator runs.

## Testing

- New `__tests__/includeComments.test.ts` (4 cases: default off, comment + sigil, quote/newline flattening, `disableEmoji` interaction). Runs against the DMMF directly via `.md` output, so it needs no browser.
- Re-ran `disableEmoji` and `nullables` end-to-end (SVG via mmdc) to confirm the sigil refactor didn't change rendering.
- Verified end-to-end against a real schema on Prisma 7 — comments show up in the rendered SVG.