### PR TITLE
feat: add `usePrismaNames` option to draw schema names instead of db names

### DIFF
--- a/.changeset/prisma-name-source.md
+++ b/.changeset/prisma-name-source.md
@@ -1,0 +1,7 @@
+---
+'prisma-erd-generator': minor
+---
+
+Add `usePrismaNames` generator option to draw schema model/field names instead of `@@map` / `@map` database names (#128)
+
+Also fixes `@@map`ed enums rendering a duplicate empty node: the relationship line referenced the enum's Prisma name while the enum block used its database name.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,33 @@ erDiagram
 
 Only `///` comments are available — plain `//` comments are dropped by Prisma before the generator runs. Comments share the attribute slot with the primary key and nullable sigils, and are flattened to a single line with `"` replaced by `'` so mermaid can parse them.
 
+### Use Prisma names instead of database names
+
+By default, models and fields carrying `@@map` / `@map` are drawn with their **database** names. Set `usePrismaNames` to draw the names as they appear in your schema instead.
+
+```prisma
+generator erd {
+  provider       = "prisma-erd-generator"
+  usePrismaNames = true
+}
+```
+
+```prisma
+model User {
+  id       Int    @id
+  nickName String @map("nick_name")
+
+  @@map("users")
+}
+```
+
+| `usePrismaNames` | Entity  | Field      |
+| ---------------- | ------- | ---------- |
+| `false` (default) | `users` | `nick_name` |
+| `true`            | `User`  | `nickName`  |
+
+This applies to models, composite types, enums, and fields.
+
 ### Disable emoji output
 
 The emoji output for primary keys (`🗝️`) and nullable fields (`❓`) can be disabled, restoring the older values of `PK` and `nullable`, respectively.

--- a/__tests__/usePrismaNames.test.ts
+++ b/__tests__/usePrismaNames.test.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { GeneratorOptions } from '@prisma/generator-helper'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import generate from '../src/generate'
+
+const tmpDir = path.join(__dirname, 'tmp-use-prisma-names')
+
+const datamodel = `
+model User {
+  id        Int      @id
+  nickName  String   @map("nick_name")
+  posts     Post[]
+  role      Role
+
+  @@map("users")
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int
+
+  @@map("posts")
+}
+
+enum Role {
+  ADMIN
+  USER
+
+  @@map("roles")
+}
+`
+
+const field = (name: string, overrides: Record<string, unknown> = {}) => ({
+    name,
+    dbName: null,
+    hasDefaultValue: false,
+    isGenerated: false,
+    isId: false,
+    isList: false,
+    isReadOnly: false,
+    isRequired: true,
+    isUnique: false,
+    isUpdatedAt: false,
+    kind: 'scalar',
+    type: 'String',
+    ...overrides,
+})
+
+const dmmfDatamodel = {
+    types: [],
+    enums: [
+        {
+            name: 'Role',
+            dbName: 'roles',
+            values: [
+                { name: 'ADMIN', dbName: null },
+                { name: 'USER', dbName: null },
+            ],
+        },
+    ],
+    models: [
+        {
+            name: 'User',
+            dbName: 'users',
+            fields: [
+                field('id', { isId: true, type: 'Int' }),
+                field('nickName', { dbName: 'nick_name' }),
+                field('posts', {
+                    kind: 'object',
+                    type: 'Post',
+                    isList: true,
+                    relationName: 'PostToUser',
+                    relationFromFields: [],
+                    relationToFields: [],
+                }),
+                field('role', { kind: 'enum', type: 'Role' }),
+            ],
+            idFields: [],
+            uniqueFields: [],
+            uniqueIndexes: [],
+            isGenerated: false,
+            primaryKey: null,
+        },
+        {
+            name: 'Post',
+            dbName: 'posts',
+            fields: [
+                field('id', { isId: true, type: 'Int' }),
+                field('author', {
+                    kind: 'object',
+                    type: 'User',
+                    relationName: 'PostToUser',
+                    relationFromFields: ['authorId'],
+                    relationToFields: ['id'],
+                }),
+                field('authorId', { type: 'Int' }),
+            ],
+            idFields: [],
+            uniqueFields: [],
+            uniqueIndexes: [],
+            isGenerated: false,
+            primaryKey: null,
+        },
+    ],
+}
+
+const render = async (
+    fileName: string,
+    config: Record<string, string> = {}
+) => {
+    const outputFile = path.join(tmpDir, fileName)
+
+    await generate({
+        generator: {
+            name: 'erd',
+            provider: { fromEnvVar: null, value: 'prisma-erd-generator' },
+            output: { fromEnvVar: null, value: outputFile },
+            config,
+            binaryTargets: [],
+            previewFeatures: [],
+            sourceFilePath: 'schema.prisma',
+        },
+        otherGenerators: [],
+        schemaPath: 'schema.prisma',
+        // the renderer mutates field names in place, so hand it a fresh copy
+        dmmf: { datamodel: JSON.parse(JSON.stringify(dmmfDatamodel)) },
+        datasources: [],
+        datamodel,
+        version: 'test',
+    } as unknown as GeneratorOptions)
+
+    return fs.readFileSync(outputFile, 'utf8')
+}
+
+describe('usePrismaNames', () => {
+    beforeEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+        fs.mkdirSync(tmpDir, { recursive: true })
+    })
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('uses @@map / @map database names by default', async () => {
+        const output = await render('db-names.md')
+
+        expect(output).toContain('"users" {')
+        expect(output).toContain('"posts" {')
+        expect(output).toContain('nick_name')
+        expect(output).not.toContain('"User" {')
+        expect(output).not.toContain('nickName')
+    })
+
+    it('uses prisma model and field names when enabled', async () => {
+        const output = await render('prisma-names.md', {
+            usePrismaNames: 'true',
+        })
+
+        expect(output).toContain('"User" {')
+        expect(output).toContain('"Post" {')
+        expect(output).toContain('nickName')
+        expect(output).not.toContain('"users" {')
+        expect(output).not.toContain('nick_name')
+    })
+
+    it('points relationships at the same node the entity was rendered as', async () => {
+        const dbNames = await render('db-relations.md')
+
+        expect(dbNames).toContain('"posts" }o--|| "users"')
+        // the enum block renders as `roles`, so the relation has to say `roles`
+        // too, otherwise mermaid draws an extra empty `Role` node
+        expect(dbNames).toContain('"users" |o--|| "roles"')
+        expect(dbNames).not.toContain('"Role"')
+
+        const prismaNames = await render('prisma-relations.md', {
+            usePrismaNames: 'true',
+        })
+
+        expect(prismaNames).toContain('"Post" }o--|| "User"')
+        expect(prismaNames).toContain('"User" |o--|| "Role"')
+        expect(prismaNames).not.toContain('"roles"')
+    })
+})

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -33,9 +33,15 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
         disableEmoji = false,
         sortFields = false,
         includeComments = false,
+        usePrismaNames = false,
     } = options ?? {}
 
     const diagram = 'erDiagram'
+
+    // `@@map` / `@map` names win by default; `usePrismaNames` keeps the schema
+    // names instead. Field names are handled upstream by `mapPrismaToDb`.
+    const displayName = (entity: { name: string; dbName?: string | null }) =>
+        usePrismaNames ? entity.name : entity.dbName || entity.name
 
     // Combine Models and Types as they are pretty similar
     // If ignoreViews is enabled, exclude views from the models
@@ -57,7 +63,7 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
             : dml.enums
                   .map(
                       (model: DMLEnum) => `
-        ${model.dbName || model.name} {
+        ${displayName(model)} {
             ${model.values
                 .map(
                     (value) =>
@@ -85,7 +91,7 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
     const classes = modellikes
         .map(
             (model) =>
-                `  "${model.dbName || model.name}" {
+                `  "${displayName(model)}" {
 ${
     tableOnly
         ? ''
@@ -127,10 +133,18 @@ ${
             }
 
             const relationshipName = `${isEnum ? 'enum:' : ''}${field.name}`
-            const thisSide = `"${model.dbName || model.name}"`
+            const thisSide = `"${displayName(model)}"`
+            // enums are searched too so that an `@@map`ed enum lands on the same
+            // node the enum block rendered, instead of an empty duplicate
+            const otherEntity =
+                modellikes.find(
+                    (ml) => ml.name === field.type || ml.dbName === field.type
+                ) ??
+                dml.enums.find(
+                    (e) => e.name === field.type || e.dbName === field.type
+                )
             const otherSide = `"${
-                modellikes.find((ml) => ml.name === field.type)?.dbName ||
-                field.type
+                otherEntity ? displayName(otherEntity) : field.type
             }"`
             // normal relations
             if (
@@ -164,9 +178,7 @@ ${
                     otherSideMultiplicity = '|o'
                 }
 
-                relationships += `    ${thisSide} ${thisSideMultiplicity}--${otherSideMultiplicity} ${
-                    otherModel?.dbName || otherSide
-                } : "${relationshipName}"\n`
+                relationships += `    ${thisSide} ${thisSideMultiplicity}--${otherSideMultiplicity} ${otherSide} : "${relationshipName}"\n`
             }
             // many to many
             else if (
@@ -229,9 +241,9 @@ ${
                         thisSideMultiplicity = 'o|'
                     }
 
-                    relationships += `    ${thisSide} ${thisSideMultiplicity}--${otherSideMultiplicity} ${
-                        otherSideCompositeType.dbName || otherSide
-                    } : "${relationshipName}"\n`
+                    relationships += `    ${thisSide} ${thisSideMultiplicity}--${otherSideMultiplicity} "${displayName(
+                        otherSideCompositeType
+                    )}" : "${relationshipName}"\n`
                 }
             }
         }
@@ -342,6 +354,7 @@ export default async (options: GeneratorOptions) => {
             config.includeRelationFromFields === 'true'
         const sortFields = config.sortFields === 'true'
         const includeComments = config.includeComments === 'true'
+        const usePrismaNames = config.usePrismaNames === 'true'
         const disabled =
             process.env.DISABLE_ERD === 'true' || config.disabled === 'true'
         const debug =
@@ -376,7 +389,9 @@ export default async (options: GeneratorOptions) => {
         }
 
         // updating dml to map to db table and column names (@map && @@map)
-        dml.models = mapPrismaToDb(dml.models)
+        if (!usePrismaNames) {
+            dml.models = mapPrismaToDb(dml.models)
+        }
 
         // default types to empty array
         if (!dml.types) {
@@ -404,6 +419,7 @@ export default async (options: GeneratorOptions) => {
             disableEmoji,
             sortFields,
             includeComments,
+            usePrismaNames,
         })
         if (debug && mermaid) {
             const mermaidFile = path.resolve('prisma/debug/3-mermaid.mmd')

--- a/types/dml.ts
+++ b/types/dml.ts
@@ -22,6 +22,7 @@ export interface DMLRendererOptions {
     disableEmoji?: boolean
     sortFields?: boolean
     includeComments?: boolean
+    usePrismaNames?: boolean
 }
 
 // Copy paste of the DMLModel

--- a/types/generator.ts
+++ b/types/generator.ts
@@ -9,6 +9,7 @@ export interface PrismaERDConfig {
     includeRelationFromFields?: string
     sortFields?: string
     includeComments?: string
+    usePrismaNames?: string
     erdDebug?: string
     puppeteerConfig?: string
     mermaidConfig?: string


### PR DESCRIPTION
Closes #128

## What

Adds an opt-in `usePrismaNames` generator option. By default models and fields carrying `@@map` / `@map` are drawn with their **database** names; with this option they keep the names as written in the schema.

```prisma
model User {
  id       Int    @id
  nickName String @map("nick_name")

  @@map("users")
}
```

| `usePrismaNames` | Entity | Field |
| --- | --- | --- |
| `false` (default) | `users` | `nick_name` |
| `true` | `User` | `nickName` |

Covers models, composite types, enums and fields — per @michaelaltmann's note on the issue that this should apply to columns too.

## Drive-by fix: `@@map`ed enums rendered twice

While wiring this up, the entity-name resolution turned out to be inconsistent. The enum block rendered `enum.dbName || enum.name`, but the relationship line only searched models/composite types, never enums — so it fell through to the enum's Prisma name:

```mermaid
erDiagram
        roles {
            ADMIN ADMIN
            USER USER
        }
    "accounts" |o--|| "Role" : "enum:role"
```

Mermaid draws that as an extra empty `Role` node next to the populated `roles` one. Relationship endpoints now resolve through the same `displayName` helper the entity blocks use, so both say `roles`.

## Output change for existing users

For schemas using `@@map`, relationship endpoints are now consistently quoted:

```diff
-    "profile" |o--|| users : "user"
+    "profile" |o--|| "users" : "user"
```

Mermaid parses both identically — this is the same node, just quoted like every other endpoint already was. Verified against `prisma/mappings.prisma`; the rest of the output is byte-identical.

## Testing

- New `__tests__/usePrismaNames.test.ts` — both naming modes plus the enum-node regression. Renders to `.md` straight from the DMMF, so no browser needed.
- Full suite (30 files / 35 tests) passes against Prisma 7.
- Diffed generated output for `prisma/mappings.prisma` before/after to confirm the default path only changed in the two ways described above.