### PR TITLE
feat: add `showIndexes` option to mark unique and indexed columns

### DIFF
--- a/.changeset/show-indexes.md
+++ b/.changeset/show-indexes.md
@@ -1,0 +1,5 @@
+---
+'prisma-erd-generator': minor
+---
+
+Add `showIndexes` generator option to mark unique (`🔒`/`UK`) and indexed (`🔍`/`IDX`) columns in the diagram (#209)

--- a/README.md
+++ b/README.md
@@ -327,6 +327,50 @@ model User {
 
 This applies to models, composite types, enums, and fields.
 
+### Show indexes
+
+Mark indexed columns so you can tell at a glance which fields a query can filter on cheaply. Disabled by default.
+
+```prisma
+generator erd {
+  provider    = "prisma-erd-generator"
+  showIndexes = true
+}
+```
+
+```prisma
+model User {
+  id        Int    @id
+  email     String @unique
+  firstName String
+  lastName  String
+  tenantId  Int
+
+  @@unique([firstName, lastName])
+  @@index([tenantId])
+}
+```
+
+```mermaid
+erDiagram
+  "User" {
+    Int id "🗝️"
+    String email "🔒"
+    String firstName "🔍"
+    String lastName "🔍"
+    Int tenantId "🔍"
+  }
+```
+
+| Marker | With `disableEmoji` | Meaning |
+| --- | --- | --- |
+| `🔒` | `UK` | the column is unique on its own (`@unique`) |
+| `🔍` | `IDX` | the column takes part in an index (`@@index`, or a `@@unique` composite) |
+
+Prisma strips `@@index` before handing the model to a generator, so it is read back out of the schema file. Composite index **order** is not shown — a column is either covered or it isn't.
+
+Markers share the attribute slot with the primary key, nullable and `includeComments` text, so a field can carry several at once.
+
 ### Disable emoji output
 
 The emoji output for primary keys (`🗝️`) and nullable fields (`❓`) can be disabled, restoring the older values of `PK` and `nullable`, respectively.

--- a/__tests__/showIndexes.test.ts
+++ b/__tests__/showIndexes.test.ts
@@ -1,0 +1,190 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { GeneratorOptions } from '@prisma/generator-helper'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import generate, { extractIndexedFields } from '../src/generate'
+
+const tmpDir = path.join(__dirname, 'tmp-show-indexes')
+
+const datamodel = `
+model User {
+  id        Int    @id
+  email     String @unique
+  firstName String @map("first_name")
+  lastName  String
+  tenantId  Int
+  bio       String
+
+  @@unique([firstName, lastName])
+  @@index([tenantId])
+  @@index(fields: [bio(sort: Desc)])
+  @@map("users")
+}
+`
+
+const field = (name: string, overrides: Record<string, unknown> = {}) => ({
+    name,
+    dbName: null,
+    hasDefaultValue: false,
+    isGenerated: false,
+    isId: false,
+    isList: false,
+    isReadOnly: false,
+    isRequired: true,
+    isUnique: false,
+    isUpdatedAt: false,
+    kind: 'scalar',
+    type: 'String',
+    ...overrides,
+})
+
+const dmmfDatamodel = {
+    enums: [],
+    types: [],
+    models: [
+        {
+            name: 'User',
+            dbName: 'users',
+            fields: [
+                field('id', { isId: true, type: 'Int' }),
+                field('email', {
+                    isUnique: true,
+                    documentation: 'Login address',
+                }),
+                field('firstName', { dbName: 'first_name' }),
+                field('lastName'),
+                field('tenantId', { type: 'Int' }),
+                field('bio'),
+            ],
+            idFields: [],
+            uniqueFields: [['firstName', 'lastName']],
+            uniqueIndexes: [{ name: null, fields: ['firstName', 'lastName'] }],
+            isGenerated: false,
+            primaryKey: null,
+        },
+    ],
+}
+
+const render = async (
+    fileName: string,
+    config: Record<string, string> = {}
+) => {
+    const outputFile = path.join(tmpDir, fileName)
+
+    await generate({
+        generator: {
+            name: 'erd',
+            provider: { fromEnvVar: null, value: 'prisma-erd-generator' },
+            output: { fromEnvVar: null, value: outputFile },
+            config,
+            binaryTargets: [],
+            previewFeatures: [],
+            sourceFilePath: 'schema.prisma',
+        },
+        otherGenerators: [],
+        schemaPath: 'schema.prisma',
+        // the renderer mutates fields in place, so hand it a fresh copy
+        dmmf: { datamodel: JSON.parse(JSON.stringify(dmmfDatamodel)) },
+        datasources: [],
+        datamodel,
+        version: 'test',
+    } as unknown as GeneratorOptions)
+
+    return fs.readFileSync(outputFile, 'utf8')
+}
+
+describe('extractIndexedFields', () => {
+    it('collects @@index fields per model', () => {
+        expect(extractIndexedFields(datamodel)).toEqual({
+            User: ['tenantId', 'bio'],
+        })
+    })
+
+    it('strips per-field modifiers and handles the fields: form', () => {
+        const schema = `
+model Post {
+  title String
+  body  String
+
+  @@index([title(sort: Desc)])
+  @@index(fields: [body(ops: raw("x")), title])
+}
+`
+        expect(extractIndexedFields(schema)).toEqual({
+            Post: ['title', 'body', 'title'],
+        })
+    })
+
+    it('does not leak indexes across models', () => {
+        const schema = `
+model A {
+  a Int
+
+  @@index([a])
+}
+
+model B {
+  b Int
+}
+`
+        expect(extractIndexedFields(schema)).toEqual({ A: ['a'] })
+    })
+
+    it('returns nothing for a schema without indexes', () => {
+        expect(extractIndexedFields('model A {\n  a Int\n}')).toEqual({})
+    })
+})
+
+describe('showIndexes', () => {
+    beforeEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+        fs.mkdirSync(tmpDir, { recursive: true })
+    })
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('marks nothing by default', async () => {
+        const output = await render('default.md')
+
+        expect(output).not.toContain('🔒')
+        expect(output).not.toContain('🔍')
+    })
+
+    it('marks unique columns and indexed columns when enabled', async () => {
+        const output = await render('indexes.md', { showIndexes: 'true' })
+
+        expect(output).toContain('String email "🔒"')
+        expect(output).toContain('Int tenantId "🔍"')
+        expect(output).toContain('String bio "🔍"')
+        // members of an @@unique composite are indexed, but not unique alone
+        expect(output).toContain('String lastName "🔍"')
+    })
+
+    it('marks @map columns, whose index is declared under the prisma name', async () => {
+        const output = await render('mapped.md', { showIndexes: 'true' })
+
+        expect(output).toContain('String first_name "🔍"')
+    })
+
+    it('shares the attribute slot with includeComments', async () => {
+        const output = await render('with-comments.md', {
+            showIndexes: 'true',
+            includeComments: 'true',
+        })
+
+        // sigils first, human text last, all inside one quoted comment
+        expect(output).toContain('String email "\u{1f512} Login address"')
+    })
+
+    it('uses text markers when disableEmoji is set', async () => {
+        const output = await render('no-emoji.md', {
+            showIndexes: 'true',
+            disableEmoji: 'true',
+        })
+
+        expect(output).toContain('String email "UK"')
+        expect(output).toContain('Int tenantId "IDX"')
+    })
+})

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -34,6 +34,7 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
         sortFields = false,
         includeComments = false,
         usePrismaNames = false,
+        showIndexes = false,
     } = options ?? {}
 
     const diagram = 'erDiagram'
@@ -79,6 +80,8 @@ function renderDml(dml: DML, options?: DMLRendererOptions) {
 
     const pkSigil = disableEmoji ? 'PK' : '🗝️'
     const nullableSigil = disableEmoji ? 'nullable' : '❓'
+    const uniqueSigil = disableEmoji ? 'UK' : '🔒'
+    const indexSigil = disableEmoji ? 'IDX' : '🔍'
     const getShownFields = (model: DMLModel) => {
         const fields = model.fields.filter(
             isFieldShownInSchema(model, includeRelationFromFields)
@@ -107,6 +110,12 @@ ${
                   }
                   if (!field.isRequired) {
                       notes.push(nullableSigil)
+                  }
+                  if (showIndexes && field.isUnique) {
+                      notes.push(uniqueSigil)
+                  }
+                  if (showIndexes && field.isIndexed) {
+                      notes.push(indexSigil)
                   }
                   if (includeComments && field.documentation) {
                       notes.push(sanitizeComment(field.documentation))
@@ -285,6 +294,78 @@ export const extractViewNames = (dataModel: string): string[] => {
 }
 
 /**
+ * Collects the fields covered by a `@@index` for every model in the schema,
+ * keyed by model name.
+ *
+ * Prisma does not put non-unique indexes on the DMMF at all — only `@unique`
+ * and `@@unique` survive — so the schema text is the only source for them.
+ */
+export const extractIndexedFields = (
+    dataModel: string
+): Record<string, string[]> => {
+    const indexed: Record<string, string[]> = {}
+    let currentModel: string | null = null
+
+    for (const rawLine of dataModel?.split('\n') ?? []) {
+        const line = rawLine.trim()
+
+        const modelMatch = line.match(/^model\s+(\w+)\s*{/)
+        if (modelMatch?.[1]) {
+            currentModel = modelMatch[1]
+            continue
+        }
+        if (line === '}') {
+            currentModel = null
+            continue
+        }
+        if (!currentModel) continue
+
+        // matches both `@@index([a, b])` and `@@index(fields: [a, b])`
+        const indexMatch = line.match(/^@@index\(\s*(?:fields\s*:\s*)?\[([^\]]+)\]/)
+        if (!indexMatch?.[1]) continue
+
+        const fields = indexMatch[1]
+            .split(',')
+            // drop per-field modifiers like `title(sort: Desc)` or `bio(length: 10)`
+            .map((field) => field.split('(')[0]?.trim())
+            .filter((field): field is string => Boolean(field))
+
+        indexed[currentModel] = (indexed[currentModel] ?? []).concat(fields)
+    }
+
+    return indexed
+}
+
+/**
+ * Flags fields that sit behind an index so the renderer can mark them.
+ *
+ * Must run before `mapPrismaToDb`, which rewrites field names to their `@map`
+ * values — the schema refers to them by their prisma names.
+ */
+export const markIndexedFields = (
+    dmlModels: DMLModel[],
+    dataModel: string
+): DMLModel[] => {
+    const indexedByModel = extractIndexedFields(dataModel)
+
+    return dmlModels.map((model) => {
+        const indexed = new Set([
+            ...(indexedByModel[model.name] ?? []),
+            // `@@unique` composites: the individual fields are not `isUnique`
+            ...(model.uniqueFields ?? []).flat(),
+        ])
+
+        for (const field of model.fields) {
+            if (indexed.has(field.name)) {
+                field.isIndexed = true
+            }
+        }
+
+        return model
+    })
+}
+
+/**
  * Converts a glob-like pattern to a RegExp
  * Supports: * (any characters), ? (single character), exact names
  * Examples:
@@ -355,6 +436,7 @@ export default async (options: GeneratorOptions) => {
         const sortFields = config.sortFields === 'true'
         const includeComments = config.includeComments === 'true'
         const usePrismaNames = config.usePrismaNames === 'true'
+        const showIndexes = config.showIndexes === 'true'
         const disabled =
             process.env.DISABLE_ERD === 'true' || config.disabled === 'true'
         const debug =
@@ -388,6 +470,10 @@ export default async (options: GeneratorOptions) => {
             console.log(`data model written to ${dataModelFile}`)
         }
 
+        // `@@index` lives only in the schema text and refers to fields by their
+        // prisma names, so this has to happen before @map rewrites them below
+        dml.models = markIndexedFields(dml.models, options.datamodel)
+
         // updating dml to map to db table and column names (@map && @@map)
         if (!usePrismaNames) {
             dml.models = mapPrismaToDb(dml.models)
@@ -420,6 +506,7 @@ export default async (options: GeneratorOptions) => {
             sortFields,
             includeComments,
             usePrismaNames,
+            showIndexes,
         })
         if (debug && mermaid) {
             const mermaidFile = path.resolve('prisma/debug/3-mermaid.mmd')

--- a/types/dml.ts
+++ b/types/dml.ts
@@ -4,7 +4,7 @@ export interface DMLModel {
     dbName: string | null
     fields: DMLField[]
     idFields?: unknown[]
-    uniqueFields?: unknown[]
+    uniqueFields?: string[][]
     uniqueIndexes?: unknown[]
     isGenerated?: boolean
     primaryKey?: {
@@ -23,6 +23,7 @@ export interface DMLRendererOptions {
     sortFields?: boolean
     includeComments?: boolean
     usePrismaNames?: boolean
+    showIndexes?: boolean
 }
 
 // Copy paste of the DMLModel
@@ -33,7 +34,7 @@ export interface DMLType {
     dbName: string | null
     fields: DMLField[]
     idFields?: unknown[]
-    uniqueFields?: unknown[]
+    uniqueFields?: string[][]
     uniqueIndexes?: unknown[]
     isGenerated: boolean
     primaryKey: {
@@ -62,6 +63,8 @@ export interface DMLField {
     default?: unknown
     /** `/// comment` above the field in the prisma schema */
     documentation?: string
+    /** set by `markIndexedFields`: covered by an `@@index` or `@@unique` */
+    isIndexed?: boolean
 }
 
 export interface DMLEnum {

--- a/types/generator.ts
+++ b/types/generator.ts
@@ -10,6 +10,7 @@ export interface PrismaERDConfig {
     sortFields?: string
     includeComments?: string
     usePrismaNames?: string
+    showIndexes?: string
     erdDebug?: string
     puppeteerConfig?: string
     mermaidConfig?: string


### PR DESCRIPTION
Closes #209

## What

Adds an opt-in `showIndexes` generator option that marks which columns sit behind an index, so you can tell from the diagram whether a query will use one.

```prisma
generator erd {
  provider    = "prisma-erd-generator"
  showIndexes = true
}

model User {
  id        Int    @id
  email     String @unique
  firstName String
  lastName  String
  tenantId  Int

  @@unique([firstName, lastName])
  @@index([tenantId])
}
```

```mermaid
erDiagram
  "User" {
    Int id "🗝️"
    String email "🔒"
    String firstName "🔍"
    String lastName "🔍"
    Int tenantId "🔍"
  }
```

| Marker | With `disableEmoji` | Meaning |
| --- | --- | --- |
| `🔒` | `UK` | unique on its own (`@unique`) |
| `🔍` | `IDX` | takes part in an index (`@@index`, or a `@@unique` composite) |

## Why it needs a schema parser

`@@index` **is not on the DMMF at all**. Prisma hands generators `uniqueFields` / `uniqueIndexes` (from `@@unique`) and `isUnique` (from `@unique`), but non-unique indexes are dropped before `onGenerate` runs — I verified this against Prisma 7 by dumping `1-datamodel.json` for a schema with three `@@index` declarations. So `extractIndexedFields` reads them back out of the schema text, in the same spirit as the existing `extractViewNames`.

The ordering matters and is the one subtle bit: `markIndexedFields` must run **before** `mapPrismaToDb`, because the schema declares indexes under the *prisma* field name while `mapPrismaToDb` rewrites `field.name` to the `@map` value. There's a test covering exactly that (`first_name` is marked from `@@index([firstName])`).

Parsing handles both `@@index([a, b])` and `@@index(fields: [a, b])`, and strips per-field modifiers like `title(sort: Desc)`.

## Deliberate limitations

- **Composite index order is not shown** — a column is either covered or it isn't. Showing position would need a marker per index membership, which gets noisy fast. Easy to add later if someone asks. Noted in the README.
- **Members of a `@@unique` composite get `🔍`, not `🔒`** — they're covered by a unique index but are not individually unique, so the weaker marker is the honest one.

## Testing

- New `__tests__/showIndexes.test.ts` — 4 unit tests on the parser (modifiers, `fields:` form, model scoping, no-index schemas) and 4 render tests (default off, unique vs index markers, `@map` interaction, `disableEmoji`).
- Full suite (30 files / 40 tests) passes against Prisma 7.
- Verified end-to-end on a real schema that default output is unchanged.