### PR TITLE
feat!: make `@mermaid-js/mermaid-cli` an optional peer dependency

### DIFF
--- a/.changeset/optional-mermaid-cli.md
+++ b/.changeset/optional-mermaid-cli.md
@@ -1,0 +1,20 @@
+---
+'prisma-erd-generator': major
+---
+
+**Breaking:** `@mermaid-js/mermaid-cli` is now an optional peer dependency instead of a hard dependency (#293, #176)
+
+It is only ever invoked as an external binary, and never at all for text output, so installing it (plus `mermaid` and a headless Chromium) for every user was dead weight. If you render `.svg` / `.png` / `.pdf`, install it yourself:
+
+```bash
+npm i -D @mermaid-js/mermaid-cli puppeteer
+```
+
+If you render `.md` or `.mmd`, you can drop it and skip the Chromium download entirely.
+
+Also in this release:
+
+- Added `.mmd` output, which writes bare mermaid with no code fence.
+- A missing mermaid CLI now fails with an actionable message naming the package to install, instead of a bare "package was not found".
+- The CLI is resolved before the puppeteer config is built, so a missing CLI no longer hides behind the arm64 `which chromium` probe.
+- The fallback `find ../.. -name mmdc` search no longer crashes where `find` is unavailable (Windows).

--- a/README.md
+++ b/README.md
@@ -8,10 +8,14 @@ Prisma generator to create an ER Diagram every time you generate your prisma cli
 
 > Like this tool? [@Skn0tt](https://github.com/Skn0tt) started this effort with his [web app ER diagram generator](https://prisma-erd.simonknott.de/)
 
+Rendering an image (`.svg`, `.png`, `.pdf`) shells out to the mermaid CLI, which brings a headless Chromium with it. That's an **optional** peer dependency, so pick the install that matches your output:
+
 ```bash
+# images — svg (the default), png, pdf
 npm i -D prisma-erd-generator @mermaid-js/mermaid-cli puppeteer
-# or
-yarn add -D prisma-erd-generator @mermaid-js/mermaid-cli puppeteer
+
+# text only — md, mmd (no browser, no Chromium download)
+npm i -D prisma-erd-generator
 ```
 
 Add to your `schema.prisma`
@@ -32,9 +36,19 @@ npx prisma generate
 
 ## Versions
 
--   Prisma >=5 use 2.x.x
+-   Prisma >=5 use 3.x.x / 2.x.x
 -   Prisma = 4 use 1.x.x
 -   Prisma <4 use 0.11.x
+
+### Upgrading to 3.x
+
+`@mermaid-js/mermaid-cli` is no longer a hard dependency. Nothing else changed — but if you output an image and relied on it being installed for you, add it explicitly:
+
+```bash
+npm i -D @mermaid-js/mermaid-cli puppeteer
+```
+
+If you output `.md` or `.mmd`, you can now drop both and skip the Chromium download entirely.
 
 ## Options
 
@@ -55,10 +69,13 @@ generator erd {
 
 Extensions
 
--   svg (default: `./prisma/ERD.svg`)
--   png
--   pdf
--   md
+| Extension | Needs `@mermaid-js/mermaid-cli` |
+| --- | --- |
+| `svg` (default: `./prisma/ERD.svg`) | yes |
+| `png` | yes |
+| `pdf` | yes |
+| `md` — mermaid in a fenced code block | no |
+| `mmd` — bare mermaid | no |
 
 ### Theme
 
@@ -84,7 +101,7 @@ This option does not accept environment variables or other dynamic values. If yo
 
 ### mmdcPath
 
-In order for this generator to succeed you must have `mmdc` installed. This is the mermaid cli tool that is used to generate the ERD. By default the generator searches for an existing binary file at `/node_modules/.bin`. If it fails to find that binary it will run `find ../.. -name mmdc` to search through your folder for a `mmdc` binary. If you are using a different package manager or have a different location for your binary files, you can specify the path to the binary file.
+To render an image you must have `mmdc` installed — it ships with the optional `@mermaid-js/mermaid-cli` peer dependency. By default the generator searches for an existing binary file at `/node_modules/.bin`. If it fails to find that binary it will run `find ../.. -name mmdc` to search through your folder for a `mmdc` binary. If you are using a different package manager or have a different location for your binary files, you can specify the path to the binary file.
 
 ```prisma
 generator erd {

--- a/__tests__/textOutput.test.ts
+++ b/__tests__/textOutput.test.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { GeneratorOptions } from '@prisma/generator-helper'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import generate from '../src/generate'
+import packageJson from '../package.json'
+
+const tmpDir = path.join(__dirname, 'tmp-text-output')
+
+const datamodel = `
+model User {
+  id    Int    @id
+  email String
+}
+`
+
+const dmmfDatamodel = {
+    enums: [],
+    types: [],
+    models: [
+        {
+            name: 'User',
+            dbName: null,
+            fields: [
+                {
+                    name: 'id',
+                    hasDefaultValue: false,
+                    isGenerated: false,
+                    isId: true,
+                    isList: false,
+                    isReadOnly: false,
+                    isRequired: true,
+                    isUnique: false,
+                    isUpdatedAt: false,
+                    kind: 'scalar',
+                    type: 'Int',
+                },
+                {
+                    name: 'email',
+                    hasDefaultValue: false,
+                    isGenerated: false,
+                    isId: false,
+                    isList: false,
+                    isReadOnly: false,
+                    isRequired: true,
+                    isUnique: false,
+                    isUpdatedAt: false,
+                    kind: 'scalar',
+                    type: 'String',
+                },
+            ],
+            idFields: [],
+            uniqueFields: [],
+            uniqueIndexes: [],
+            isGenerated: false,
+            primaryKey: null,
+        },
+    ],
+}
+
+const render = async (fileName: string) => {
+    const outputFile = path.join(tmpDir, fileName)
+
+    await generate({
+        generator: {
+            name: 'erd',
+            provider: { fromEnvVar: null, value: 'prisma-erd-generator' },
+            output: { fromEnvVar: null, value: outputFile },
+            config: {},
+            binaryTargets: [],
+            previewFeatures: [],
+            sourceFilePath: 'schema.prisma',
+        },
+        otherGenerators: [],
+        schemaPath: 'schema.prisma',
+        dmmf: { datamodel: JSON.parse(JSON.stringify(dmmfDatamodel)) },
+        datasources: [],
+        datamodel,
+        version: 'test',
+    } as unknown as GeneratorOptions)
+
+    return fs.readFileSync(outputFile, 'utf8')
+}
+
+describe('browser-free text output', () => {
+    beforeEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+        fs.mkdirSync(tmpDir, { recursive: true })
+    })
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('wraps .md output in a mermaid code fence', async () => {
+        const output = await render('erd.md')
+
+        expect(output.startsWith('```mermaid\nerDiagram')).toBe(true)
+        expect(output.endsWith('```\n')).toBe(true)
+        expect(output).toContain('"User" {')
+    })
+
+    it('writes .mmd output as bare mermaid', async () => {
+        const output = await render('erd.mmd')
+
+        expect(output.startsWith('erDiagram')).toBe(true)
+        expect(output).not.toContain('```')
+        expect(output).toContain('"User" {')
+    })
+
+    it('keeps the mermaid CLI out of the required install', () => {
+        // .md / .mmd never shell out to mmdc, so a plain install must not drag
+        // in the CLI and its headless Chromium — see #293 / #176
+        expect(packageJson.dependencies).not.toHaveProperty(
+            '@mermaid-js/mermaid-cli'
+        )
+        expect(packageJson.peerDependenciesMeta).toHaveProperty(
+            ['@mermaid-js/mermaid-cli', 'optional'],
+            true
+        )
+    })
+})

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@changesets/cli": "^2.29.6",
+    "@mermaid-js/mermaid-cli": "^11.9.0",
     "all-contributors-cli": "^6.26.1",
     "concurrently": "^9.2.1",
     "cross-env": "^7.0.3",
@@ -123,11 +124,16 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@mermaid-js/mermaid-cli": "^11.9.0",
     "@prisma/generator-helper": "^7.0.0",
     "dotenv": "^16.6.1"
   },
   "peerDependencies": {
-    "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "@mermaid-js/mermaid-cli": "^11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@mermaid-js/mermaid-cli": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@mermaid-js/mermaid-cli':
-        specifier: ^11.9.0
-        version: 11.9.0(@types/react@19.2.6)(puppeteer@23.11.1(typescript@5.9.2))
       '@prisma/client':
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
         version: 6.15.0(prisma@7.0.0(@types/react@19.2.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2))(typescript@5.9.2)
@@ -27,6 +24,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.6
         version: 2.29.6(@types/node@24.3.1)
+      '@mermaid-js/mermaid-cli':
+        specifier: ^11.9.0
+        version: 11.9.0(@types/react@19.2.6)(puppeteer@23.11.1(typescript@5.9.2))
       all-contributors-cli:
         specifier: ^6.26.1
         version: 6.26.1

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -304,6 +304,51 @@ export const matchesIgnorePattern = (
     })
 }
 
+/**
+ * Last-ditch search for the `mmdc` binary outside the local `node_modules/.bin`
+ * — hoisted installs and monorepos routinely put it a couple of levels up.
+ *
+ * `find` does not exist on stock Windows, and a missing directory makes it exit
+ * non-zero, so a failed search is a "not found", never a crash.
+ */
+const findMmdc = (): string | undefined => {
+    try {
+        const found = child_process
+            .execSync('find ../.. -name mmdc', { stdio: ['ignore', 'pipe', 'ignore'] })
+            .toString()
+            .split('\n')
+            .filter((line) => line)
+            .pop()
+
+        return found && fs.existsSync(found) ? path.resolve(found) : undefined
+    } catch {
+        return undefined
+    }
+}
+
+const missingMermaidCliMessage = (searchedPath: string) =>
+    `
+prisma-erd-generator: could not find the mermaid CLI (mmdc).
+
+Rendering to .svg, .png or .pdf needs @mermaid-js/mermaid-cli, which is an
+optional peer dependency so that it is not installed for everyone:
+
+    npm i -D @mermaid-js/mermaid-cli puppeteer
+
+Already installed? Point the generator at the binary instead:
+
+    generator erd {
+      provider = "prisma-erd-generator"
+      mmdcPath = "node_modules/.bin"
+    }
+
+Don't need an image? Markdown output renders with no browser at all:
+
+    output = "../ERD.md"
+
+Searched ${searchedPath} and \`find ../.. -name mmdc\`.
+`
+
 export const mapPrismaToDb = (dmlModels: DMLModel[]) => {
     return dmlModels.map((model) => {
         return {
@@ -414,8 +459,12 @@ export default async (options: GeneratorOptions) => {
         if (!mermaid)
             throw new Error('failed to construct mermaid instance from dml')
 
+        // Text output is rendered here and needs no browser, so return before
+        // anything reaches for the mermaid CLI.
         if (output.endsWith('.md'))
             return fs.writeFileSync(output, `\`\`\`mermaid\n${mermaid}\`\`\`\n`)
+
+        if (output.endsWith('.mmd')) return fs.writeFileSync(output, mermaid)
 
         const tempMermaidFile = path.resolve(path.join(tmpDir, 'prisma.mmd'))
         fs.writeFileSync(tempMermaidFile, mermaid)
@@ -446,6 +495,23 @@ export default async (options: GeneratorOptions) => {
 
         const tempConfigFile = path.resolve(path.join(tmpDir, 'config.json'))
         fs.writeFileSync(tempConfigFile, JSON.stringify(mermaidConfig))
+
+        // Resolve the CLI before hunting for a browser: the puppeteer config
+        // below only exists to be handed to mmdc, so without mmdc its noise
+        // (including the arm64 `which chromium` probe) buries the real problem.
+        if (config.mmdcPath) {
+            if (!fs.existsSync(mermaidCliNodePath)) {
+                throw new Error(
+                    `\nMermaid CLI provided path does not exist. \n${mermaidCliNodePath}`
+                )
+            }
+        } else if (!fs.existsSync(mermaidCliNodePath)) {
+            const findMermaidCli = findMmdc()
+            if (!findMermaidCli) {
+                throw new Error(missingMermaidCliMessage(mermaidCliNodePath))
+            }
+            mermaidCliNodePath = findMermaidCli
+        }
 
         // Generator option to adjust puppeteer
         let puppeteerConfig = config.puppeteerConfig
@@ -496,26 +562,6 @@ export default async (options: GeneratorOptions) => {
                 JSON.stringify(puppeteerConfigJson)
             )
             puppeteerConfig = tempPuppeteerConfigFile
-        }
-        if (config.mmdcPath) {
-            if (!fs.existsSync(mermaidCliNodePath)) {
-                throw new Error(
-                    `\nMermaid CLI provided path does not exist. \n${mermaidCliNodePath}`
-                )
-            }
-        } else if (!fs.existsSync(mermaidCliNodePath)) {
-            const findMermaidCli = child_process
-                .execSync('find ../.. -name mmdc')
-                .toString()
-                .split('\n')
-                .filter((path) => path)
-                .pop()
-            if (!findMermaidCli || !fs.existsSync(findMermaidCli)) {
-                throw new Error(
-                    `Expected mermaid CLI at \n${mermaidCliNodePath}\n\nor\n${findMermaidCli}\n but this package was not found.`
-                )
-            }
-            mermaidCliNodePath = path.resolve(findMermaidCli)
         }
 
         const mermaidCommand = `"${mermaidCliNodePath}" -i "${tempMermaidFile}" -o "${output}" -c "${tempConfigFile}" -p "${puppeteerConfig}"`


### PR DESCRIPTION
Closes #293
Closes #176

⚠️ **Breaking — this is the 3.0 change.** Ships as a `major` changeset.

## What

`mmdc` is only ever invoked as an external binary (`node_modules/.bin/mmdc`), never imported. And for `.md` output `generate` returns long before anything touches it. So every user was installing the CLI — plus `mermaid` (~76 MB) and a headless Chromium via its `puppeteer` peer — whether or not they could ever use it.

It moves to an optional peer:

```jsonc
"peerDependencies": {
  "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
  "@mermaid-js/mermaid-cli": "^11.0.0"
},
"peerDependenciesMeta": {
  "@mermaid-js/mermaid-cli": { "optional": true }
}
```

Thanks @RPDeshaies and @mo-ayala for the original Docker-image write-up on #176 — this is the fix for that.

## Migration

Rendering `.svg` / `.png` / `.pdf` — the default output is `./prisma/ERD.svg`, so this is most people:

```bash
npm i -D @mermaid-js/mermaid-cli puppeteer
```

Rendering `.md` / `.mmd`: nothing to do, and you can now drop both packages.

The README install block, the output-extension table, and a "Upgrading to 3.x" section all say this.

## Also in here

Small things that only make sense alongside the above:

- **`.mmd` output** — writes bare mermaid with no code fence. #176 asked for `.md`/`.mmd`; only `.md` existed.
- **An actionable error.** Previously a missing CLI gave `Expected mermaid CLI at <path> or undefined but this package was not found.` Now:

  ```
  prisma-erd-generator: could not find the mermaid CLI (mmdc).

  Rendering to .svg, .png or .pdf needs @mermaid-js/mermaid-cli, which is an
  optional peer dependency so that it is not installed for everyone:

      npm i -D @mermaid-js/mermaid-cli puppeteer

  Already installed? Point the generator at the binary instead:

      generator erd {
        provider = "prisma-erd-generator"
        mmdcPath = "node_modules/.bin"
      }

  Don't need an image? Markdown output renders with no browser at all:

      output = "../ERD.md"

  Searched <path> and `find ../.. -name mmdc`.
  ```

- **CLI resolved before the puppeteer config is built.** That config exists only to be passed to `mmdc`, so building it first meant a missing CLI got buried under the arm64 `which chromium` probe dumping a `Command failed: which chromium` stack trace first. Verified before/after in an isolated directory.
- **`find ../.. -name mmdc` no longer crashes.** It was an unguarded `execSync`, so on Windows (no `find`) or a missing parent it threw a spawn error instead of falling through to "not found" — plausibly part of #183. Now a failed search is just a miss.

## Testing

- New `__tests__/textOutput.test.ts` — `.md` fencing, `.mmd` bare output, and a guard that `@mermaid-js/mermaid-cli` stays out of `dependencies` and stays marked optional, so this doesn't silently regress.
- Full suite (30 files / 35 tests) passes against Prisma 7. `@mermaid-js/mermaid-cli` moved to `devDependencies`, so CI and local runs still render real SVGs.
- Manually reproduced the missing-CLI path in an isolated directory with no `node_modules` to confirm the message and the ordering fix.