### PR TITLE
test: pin generated id defaults, including `ulid()`

### DIFF
--- a/__tests__/issues/259.test.ts
+++ b/__tests__/issues/259.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { GeneratorOptions } from '@prisma/generator-helper'
+import { afterEach, beforeEach, expect, test } from 'vitest'
+import generate from '../../src/generate'
+
+const tmpDir = path.join(__dirname, 'tmp-259')
+
+/**
+ * issue 259: ULID ids
+ *
+ * The renderer never reads `field.default`, so an id renders from its scalar
+ * type and `isId` regardless of which function produced it. This pins that
+ * down for every generated-id function Prisma offers, so a future change that
+ * starts special-casing defaults can't silently drop support for one.
+ *
+ * Kept off the schema-driven e2e harness on purpose: `ulid()` only exists from
+ * Prisma 6 on, and CI runs the suite against 5.22 as well.
+ */
+const ID_FUNCTIONS = [
+    { fn: 'ulid', type: 'String' },
+    { fn: 'cuid', type: 'String' },
+    { fn: 'uuid', type: 'String' },
+    { fn: 'nanoid', type: 'String' },
+    { fn: 'autoincrement', type: 'Int' },
+]
+
+const datamodel = ID_FUNCTIONS.map(
+    ({ fn, type }) => `model ${fn}Model {
+  id ${type} @id @default(${fn}())
+}`
+).join('\n\n')
+
+const dmmfDatamodel = {
+    enums: [],
+    types: [],
+    models: ID_FUNCTIONS.map(({ fn, type }) => ({
+        name: `${fn}Model`,
+        dbName: null,
+        fields: [
+            {
+                name: 'id',
+                hasDefaultValue: true,
+                default: { name: fn, args: [] },
+                isGenerated: false,
+                isId: true,
+                isList: false,
+                isReadOnly: false,
+                isRequired: true,
+                isUnique: false,
+                isUpdatedAt: false,
+                kind: 'scalar',
+                type,
+            },
+        ],
+        idFields: [],
+        uniqueFields: [],
+        uniqueIndexes: [],
+        isGenerated: false,
+        primaryKey: null,
+    })),
+}
+
+beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    fs.mkdirSync(tmpDir, { recursive: true })
+})
+
+afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+test('issue 259: generated id defaults all render as primary keys', async () => {
+    const outputFile = path.join(tmpDir, 'erd.md')
+
+    await generate({
+        generator: {
+            name: 'erd',
+            provider: { fromEnvVar: null, value: 'prisma-erd-generator' },
+            output: { fromEnvVar: null, value: outputFile },
+            config: { disableEmoji: 'true' },
+            binaryTargets: [],
+            previewFeatures: [],
+            sourceFilePath: 'schema.prisma',
+        },
+        otherGenerators: [],
+        schemaPath: 'schema.prisma',
+        dmmf: { datamodel: dmmfDatamodel },
+        datasources: [],
+        datamodel,
+        version: 'test',
+    } as unknown as GeneratorOptions)
+
+    const output = fs.readFileSync(outputFile, 'utf8')
+
+    for (const { fn, type } of ID_FUNCTIONS) {
+        expect(output).toContain(`"${fn}Model" {`)
+        expect(output).toContain(`${type} id "PK"`)
+    }
+})


### PR DESCRIPTION
Closes #259

## TL;DR — ULID already works, no code change needed

I ran @alexwork1611's schema from the issue against the current toolchain:

```prisma
model Company {
  id    String @id @default(ulid())
  name  String
  email String @unique

  orders    Order[]
  customers Customer[]
}
```

```mermaid
erDiagram
  "Company" {
    String id "🗝️"
    String name
    String email
  }
  "Order" }o--|| "Company" : "company"
  "Customer" }o--|| "Company" : "company"
```

Renders correctly on **Prisma 6.15 and 7.0**. It fails on **Prisma 5.22**, but not because of this generator — 5.22's own schema validator rejects it:

```
error: Unknown function in @default(): `ulid` is not known.
```

`ulid()` is a Prisma 6 feature. The reason this looked broken historically is that the generator used to shell out to a query engine to get the DMMF; it now consumes the DMMF Prisma hands it, so any `@default()` function Prisma understands passes straight through.

## What this PR adds

Just the regression guard. The renderer never reads `field.default` — an id renders from its scalar type and `isId` — so this pins that down for `ulid`, `cuid`, `uuid`, `nanoid` and `autoincrement`, and a future change that starts special-casing defaults can't silently drop one.

It's a DMMF-level test rather than a `prisma/issues/259.prisma` e2e fixture on purpose: CI runs the matrix against 5.22.0, where a schema containing `ulid()` won't parse at all.

@hongkongkiwi @grMLEqomlkkU5Eeinz4brIrOVCUCkJuN — worth retesting on 2.4.x if you're still on an older version.