### PR TITLE
fix: apply `mermaidConfig` from CommonJS config files

### DIFF
--- a/.changeset/mermaid-config-interop.md
+++ b/.changeset/mermaid-config-interop.md
@@ -1,0 +1,7 @@
+---
+'prisma-erd-generator': patch
+---
+
+Fix `mermaidConfig` being silently ignored for CommonJS config files
+
+`await import()` wraps `module.exports = config` in a namespace object, so the whole config was spread in under a `default` key and never reached mermaid — including for the shape documented in the README and shipped as `example-mermaid-config.js`.

--- a/__tests__/mermaidConfig.test.ts
+++ b/__tests__/mermaidConfig.test.ts
@@ -1,0 +1,59 @@
+import * as child_process from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterAll, beforeAll, expect, test } from 'vitest'
+
+const tmpDir = path.join(__dirname, 'tmp-mermaid-config')
+const outputFile = path.join(tmpDir, 'erd.svg')
+
+const schemaPath = path.join(tmpDir, 'schema.prisma')
+const cjsConfigPath = path.join(tmpDir, 'mermaid.config.cjs')
+
+beforeAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    fs.mkdirSync(tmpDir, { recursive: true })
+
+    // the shape the README and example-mermaid-config.js document
+    fs.writeFileSync(
+        cjsConfigPath,
+        'module.exports = { er: { useMaxWidth: false } }\n'
+    )
+    fs.writeFileSync(
+        schemaPath,
+        `generator erd {
+    provider      = "node ${path
+        .resolve(__dirname, '../dist/index.cjs')
+        .replace(/\\/g, '/')}"
+    output        = "${outputFile.replace(/\\/g, '/')}"
+    mermaidConfig = "${cjsConfigPath.replace(/\\/g, '/')}"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}
+
+model User {
+    id    Int    @id
+    email String
+}
+`
+    )
+})
+
+afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+test('a commonjs mermaidConfig is applied, not buried under `default`', () => {
+    child_process.execSync(`prisma generate --schema ${schemaPath}`)
+
+    const svg = fs.readFileSync(outputFile, 'utf8')
+
+    // useMaxWidth: false makes mermaid emit absolute dimensions. If the config
+    // were ignored the default (true) would give width="100%" + a max-width
+    // style, which is also what stops Inkscape rendering the file (#245).
+    expect(svg).toMatch(/width="\d/)
+    expect(svg).toMatch(/height="\d/)
+    expect(svg).not.toContain('width="100%"')
+})

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -433,7 +433,11 @@ export default async (options: GeneratorOptions) => {
 
         if (config?.mermaidConfig) {
             const configPath = path.resolve(config.mermaidConfig)
-            const importedMermaidConfig = await import(pathToFileURL(configPath).href)
+            const imported = await import(pathToFileURL(configPath).href)
+            // `module.exports = config` and `export default config` both arrive
+            // wrapped in a namespace object; spreading that would bury the whole
+            // config under a `default` key and silently ignore it
+            const importedMermaidConfig = imported.default ?? imported
             if (debug) {
                 console.log('imported mermaid config: ', importedMermaidConfig)
             }


### PR DESCRIPTION
Refs #245

## The bug

`mermaidConfig` has been a no-op for CommonJS config files — which is the shape the README documents and `example-mermaid-config.js` ships.

```ts
const importedMermaidConfig = await import(pathToFileURL(configPath).href)
mermaidConfig = { ...defaultMermaidConfig, ...importedMermaidConfig }
```

`await import()` returns a namespace object, so `module.exports = config` arrives as `{ default: config }`:

```
keys:   [ 'default' ]
spread: {"default":{"er":{"useMaxWidth":false}}}
```

Spreading that puts the entire user config under a `default` key, where mermaid ignores it. This repo's own `prisma/schema.prisma` points at `example-mermaid-config.js`, so even the project's committed `ERD.svg` was generated with its config discarded.

The fix unwraps the default export before merging. ESM configs with named exports still work — `imported.default ?? imported`.

## Why I went looking: #245 (Inkscape)

Mermaid's `useMaxWidth: true` — which this generator sets by default — emits:

```html
<svg viewBox="0 0 2118 2215" style="max-width: 2118.89px" width="100%">
```

No `height`, and a percentage width. That's the classic reason Inkscape renders a mermaid SVG blank or clipped, matching @keonik's screenshot. The documented escape hatch is exactly the one in `example-mermaid-config.js`:

```js
module.exports = { er: { useMaxWidth: false } }
```

…which, because of this bug, did nothing. With the fix:

```html
<svg viewBox="0 0 192.296875 144.25" height="144.25" width="192.296875">
```

Absolute dimensions, which is what Inkscape wants. I don't have Inkscape here to confirm the render, so I've left #245 open rather than claiming it fixed — but this unblocks the workaround, and it'd be worth asking the reporter to retest.

## Testing

- New `__tests__/mermaidConfig.test.ts` writes a CJS config, runs a real `prisma generate`, and asserts the SVG has absolute `width`/`height` rather than `width="100%"`. **Verified it fails on `main`** (`expected … not to contain 'width="100%"'`) and passes with the fix.
- Confirmed by hand that an ESM `export default` config also applies (checked a `theme: 'dark'` override reaching the output).
- Full suite (30 files / 33 tests) passes against Prisma 7.