### PR TITLE
fix: find the mermaid CLI on Windows when bun installed it

### DIFF
--- a/.changeset/windows-mmdc-shims.md
+++ b/.changeset/windows-mmdc-shims.md
@@ -1,0 +1,9 @@
+---
+'prisma-erd-generator': patch
+---
+
+Find the mermaid CLI on Windows when it was installed by bun
+
+The generator looked for an extensionless `node_modules/.bin/mmdc`. Windows has no extensionless executables, so package managers write shims instead — npm and pnpm write both a `mmdc` shell script and a `mmdc.cmd`, which is why this went unnoticed, but bun writes only `mmdc.exe`. On a Windows project installed with bun, `.svg` / `.png` / `.pdf` output failed with "could not find the mermaid CLI (mmdc)" despite a correct install, and the `find ../.. -name mmdc` fallback cannot help because `find` is not present on stock Windows.
+
+Resolution now probes `mmdc`, `mmdc.cmd`, `mmdc.exe` and `mmdc.ps1` on Windows, so it no longer depends on which package manager did the install. This applies to `mmdcPath` too.

--- a/__tests__/binaryResolution.test.ts
+++ b/__tests__/binaryResolution.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { binaryCandidates, resolveBinary } from '../src/generate'
+
+const tmpDir = path.join(__dirname, 'tmp-binary-resolution')
+
+const isWindows = process.platform === 'win32'
+
+describe('mermaid CLI binary resolution', () => {
+    beforeAll(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+        fs.mkdirSync(tmpDir, { recursive: true })
+    })
+
+    afterAll(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('probes shim extensions only on windows', () => {
+        const candidates = binaryCandidates('/somewhere/mmdc')
+
+        if (isWindows) {
+            // bun writes only `mmdc.exe`; npm and pnpm write `mmdc` + `mmdc.cmd`
+            expect(candidates).toEqual([
+                '/somewhere/mmdc',
+                '/somewhere/mmdc.cmd',
+                '/somewhere/mmdc.exe',
+                '/somewhere/mmdc.ps1',
+            ])
+        } else {
+            expect(candidates).toEqual(['/somewhere/mmdc'])
+        }
+    })
+
+    it('finds an extensionless binary on any platform', () => {
+        const bare = path.join(tmpDir, 'bare')
+        fs.writeFileSync(bare, '')
+
+        expect(resolveBinary(bare)).toBe(bare)
+    })
+
+    it('returns undefined when nothing matches', () => {
+        expect(resolveBinary(path.join(tmpDir, 'absent'))).toBeUndefined()
+    })
+
+    it.skipIf(!isWindows)(
+        'finds a .cmd shim when the extensionless file is absent',
+        () => {
+            const shimBase = path.join(tmpDir, 'cmdonly')
+            fs.writeFileSync(`${shimBase}.cmd`, '')
+
+            // this is the bun-on-Windows layout that used to report
+            // "could not find the mermaid CLI (mmdc)" despite a working install
+            expect(resolveBinary(shimBase)).toBe(`${shimBase}.cmd`)
+        }
+    )
+})

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -404,6 +404,22 @@ export const matchesIgnorePattern = (
  * `find` does not exist on stock Windows, and a missing directory makes it exit
  * non-zero, so a failed search is a "not found", never a crash.
  */
+/**
+ * Candidate filenames for a bin shim.
+ *
+ * Windows has no extensionless executables, so package managers write shims —
+ * and which ones they write differs by installer. npm and pnpm write both a
+ * `mmdc` shell script and a `mmdc.cmd`; bun writes only `mmdc.exe`. Probing the
+ * variants keeps resolution from depending on who did the install.
+ */
+export const binaryCandidates = (binPath: string) =>
+    process.platform === 'win32'
+        ? [binPath, `${binPath}.cmd`, `${binPath}.exe`, `${binPath}.ps1`]
+        : [binPath]
+
+export const resolveBinary = (binPath: string) =>
+    binaryCandidates(binPath).find((candidate) => fs.existsSync(candidate))
+
 const findMmdc = (): string | undefined => {
     try {
         const found = child_process
@@ -607,17 +623,19 @@ export default async (options: GeneratorOptions) => {
         // below only exists to be handed to mmdc, so without mmdc its noise
         // (including the arm64 `which chromium` probe) buries the real problem.
         if (config.mmdcPath) {
-            if (!fs.existsSync(mermaidCliNodePath)) {
+            const resolved = resolveBinary(mermaidCliNodePath)
+            if (!resolved) {
                 throw new Error(
                     `\nMermaid CLI provided path does not exist. \n${mermaidCliNodePath}`
                 )
             }
-        } else if (!fs.existsSync(mermaidCliNodePath)) {
-            const findMermaidCli = findMmdc()
-            if (!findMermaidCli) {
+            mermaidCliNodePath = resolved
+        } else {
+            const resolved = resolveBinary(mermaidCliNodePath) ?? findMmdc()
+            if (!resolved) {
                 throw new Error(missingMermaidCliMessage(mermaidCliNodePath))
             }
-            mermaidCliNodePath = findMermaidCli
+            mermaidCliNodePath = resolved
         }
 
         // Generator option to adjust puppeteer


### PR DESCRIPTION
Found while migrating CI to bun (#304), but it is a real user-facing bug independent of that work.

## The bug

Resolution builds `node_modules/.bin/mmdc` and `existsSync`-checks it. Windows has no extensionless executables, so package managers write shims instead — and **which** shims differs by installer:

| installer | writes |
| --- | --- |
| npm, pnpm | `mmdc` (shell script) **and** `mmdc.cmd` |
| bun | only `mmdc.exe` |

The extensionless file npm and pnpm happen to write is why this went unnoticed. On a Windows project installed with bun, `.svg` / `.png` / `.pdf` output fails with `could not find the mermaid CLI (mmdc)` despite a completely correct install.

The `find ../.. -name mmdc` fallback cannot rescue it either — `find` is not present on stock Windows, which the existing code already accounts for by treating a failed search as "not found".

## The fix

Probe the shim variants on win32 (`mmdc`, `mmdc.cmd`, `mmdc.exe`, `mmdc.ps1`) so resolution no longer depends on who did the install. Non-Windows behaviour is unchanged — a single candidate, same as before.

Applies to the `mmdcPath` option too, which had the same assumption.

## Tests

`__tests__/binaryResolution.test.ts` — candidate list per platform, extensionless resolution, the not-found case, plus a Windows-gated test for the `.cmd`-only layout that reproduces the reported failure.

Verified on the CI Windows matrix rather than only locally, since the interesting path only exists there.