### PR TITLE
fix(ci): drop the --access flag that broke the 3.0.1 publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "ci:publish": "bun run build && changeset publish --access public",
+    "ci:publish": "bun run build && changeset publish",
     "dev": "tsup src --watch",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",


### PR DESCRIPTION
**3.0.1 did not publish.** npm is still on 3.0.0. This unblocks it.

## What happened

```
$ changeset publish --access public
🦋  error Unknown flag for publish: --access
🦋  error Usage: changeset publish [--tag <name>] [--otp <code>] [--no-git-tag]
```

**Not OIDC.** Trusted publishing authenticated fine — the log shows `No NPM_TOKEN found, but OIDC is available - using npm trusted publishing`. The build succeeded too; it died on the publish invocation itself.

## Why it broke now, after working for 3.0.0

| | `@changesets/cli` | `--access` |
| --- | --- | --- |
| v3.0.0 (`pnpm-lock.yaml`) | 2.29.6 | supported |
| now (`bun.lock`) | **2.31.1** | **removed** |

Moving off pnpm regenerated the lockfile, which resolved `^2.29.6` up to 2.31.1. That's a fallout of the migration — not of bun itself, but of any lockfile regeneration. Worth noting for the next time we regenerate one.

The flag was redundant regardless: `publishConfig.access` is already `"public"` in `package.json`, which is the documented way to set it.

## ⚠️ This PR has no changeset on purpose

`changesets/action` has this branch:

```js
case hasChangesets && !hasNonEmptyChangesets:
  core.info("All changesets are empty; not creating PR");
  return;   // ← returns WITHOUT publishing
```

An empty changeset would send the action down that path and **leave 3.0.1 unpublished for another cycle**. `main` currently has zero changesets, which is the state that triggers "no changesets found, attempting to publish any unpublished packages" — the path we need.

So **the `changeset` check will fail on this PR, and that is the correct outcome.** It needs a merge past the failing check.

## What happens after merge

`main` is already at version 3.0.1 with its changelog written — only the npm publish failed. On merge, the publish workflow re-runs, sees 3.0.1 unpublished, and ships it. No re-versioning needed.

## Follow-up worth considering

The guard can't distinguish "release tooling fix" from "shipped code with no changelog entry". This is the first real false positive; if it happens again, an escape hatch better than "merge past a red check" is worth adding.