### PR TITLE
ci: add a skip-changeset label instead of empty changesets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,19 @@ jobs:
   changeset:
     # A PR that changes shipped code without a changeset merges fine and then
     # releases nothing — `sortFields` (#287) shipped in 2.4.4 and never made
-    # the changelog that way. Docs/CI-only work satisfies this with
-    # `bunx changeset add --empty`, which records that no release is intended.
+    # the changelog that way.
+    #
+    # Docs- or CI-only work uses the `skip-changeset` label. An empty changeset
+    # looks like the tidier answer but is a trap: changesets/action bails on
+    # "All changesets are empty; not creating PR" *without publishing*, so an
+    # empty changeset sitting on main blocks any pending release. That is how
+    # #308 nearly stranded 3.0.1 a second time.
+    #
     # Skipped on the release PR itself, which consumes every changeset.
-    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
+    if: >-
+      github.event_name == 'pull_request'
+      && github.head_ref != 'changeset-release/main'
+      && !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,15 @@ jobs:
     # releases nothing — `sortFields` (#287) shipped in 2.4.4 and never made
     # the changelog that way.
     #
-    # Docs- or CI-only work uses the `skip-changeset` label. An empty changeset
+    # Docs- or CI-only work uses the `skip-changeset` label, read live from the
+    # API in the step below. An empty changeset
     # looks like the tidier answer but is a trap: changesets/action bails on
     # "All changesets are empty; not creating PR" *without publishing*, so an
     # empty changeset sitting on main blocks any pending release. That is how
     # #308 nearly stranded 3.0.1 a second time.
     #
     # Skipped on the release PR itself, which consumes every changeset.
-    if: >-
-      github.event_name == 'pull_request'
-      && github.head_ref != 'changeset-release/main'
-      && !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -47,8 +45,19 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
+      # The label is read live rather than from github.event.pull_request.labels:
+      # the payload is frozen at the triggering event, so a label added after the
+      # PR opened would not count, and even a re-run replays the stale payload.
       - name: Require a changeset
-        run: bunx changeset status --since=origin/main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh pr view "${{ github.event.pull_request.number }}" \
+               --json labels --jq '.labels[].name' | grep -qx 'skip-changeset'; then
+            echo "skip-changeset label present — no changeset required."
+            exit 0
+          fi
+          bunx changeset status --since=origin/main
 
   smoke-test:
     strategy:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,15 @@ manage or rotate.
    Pick the bump level (patch/minor/major) and write a human-readable summary —
    this becomes the changelog entry users read.
 
+   CI enforces this: a PR that touches the package without a changeset fails the
+   `changeset` check. For docs- or CI-only work that genuinely needs no release,
+   apply the **`skip-changeset`** label instead.
+
+   Do *not* reach for `bunx changeset add --empty` to silence the check. An empty
+   changeset makes `changesets/action` stop at *"All changesets are empty; not
+   creating PR"* **without publishing**, so one sitting on `main` blocks any pending
+   release — see #308, where it would have stranded `3.0.1` a second time.
+
 2. **Merging changesets to `main`** triggers the `Publish` workflow, which opens (or
    updates) a **"Version Packages"** PR. That PR bumps the version and updates
    `CHANGELOG.md`.


### PR DESCRIPTION
Closes the escape-hatch gap that forced #308 to be merged past a red check.

## The problem

The changeset guard can't distinguish *"release-tooling fix"* from *"shipped code with no changelog entry"*. #308 was the first real false positive, and the only way through was merging with a failing check — a bad habit to establish.

## Why not `changeset add --empty`

That was the documented workaround, and it's a trap. `changesets/action` has this branch:

```js
case hasChangesets && !hasNonEmptyChangesets:
  core.info("All changesets are empty; not creating PR");
  return;   // ← returns WITHOUT publishing
```

An empty changeset sitting on `main` **blocks any pending release**. In #308 that was not hypothetical: 3.0.1 was already versioned and waiting to publish, and adding an empty changeset would have stranded it for another cycle.

So the workaround we shipped in #303 was capable of breaking releases. This replaces it.

## The fix

```yaml
if: >-
  github.event_name == 'pull_request'
  && github.head_ref != 'changeset-release/main'
  && !contains(github.event.pull_request.labels.*.name, 'skip-changeset')
```

A label states the same intent without touching release state. `skip-changeset` is created on the repo.

`RELEASING.md` documents the label and explicitly warns against the empty-changeset approach, with the reason.

## Dogfood

**This PR carries the `skip-changeset` label**, so the `changeset` job should skip rather than fail. For `pull_request` events GitHub evaluates the workflow from the merge commit, so the new condition is live on this PR — which makes it its own test.