### PR TITLE
fix(test): install each Prisma version instead of using bunx

### DIFF
--- a/vitest.global-setup.mjs
+++ b/vitest.global-setup.mjs
@@ -1,19 +1,56 @@
 import child_process from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-// Each test worker shells out to `bunx prisma@<version>`. bunx populates a
-// shared cache dir per package@version, and concurrent workers racing to fill
-// it fails with `ENOENT: failed copying files from cache to destination`.
-// Warming each version once, serially, before any worker starts means the
-// workers only ever read an already-populated cache.
-export default function warmPrismaCache() {
-    const versions = process.env.PRISMA_TEST_VERSIONS?.split(',')
-        .map((v) => v.trim())
+const rootDir = path.dirname(fileURLToPath(import.meta.url))
+
+export const versionsUnderTest = () =>
+    process.env.PRISMA_TEST_VERSIONS?.split(',')
+        .map((version) => version.trim())
         .filter(Boolean) || ['5.22.0', '6.15.0', '7.0.0']
 
-    for (const version of versions) {
-        child_process.execSync(`bunx prisma@${version} --version`, {
+export const prismaInstallDir = (version) =>
+    path.join(rootDir, 'tmp', 'prisma-cli', `v${version.replace(/\./g, '_')}`)
+
+/**
+ * Installs each Prisma version under test into its own directory.
+ *
+ * The tests used to invoke `bunx prisma@<version>`, but bunx keeps ONE cache
+ * directory per package@version and will re-resolve into it at will — moving
+ * the existing tree aside to `.old-<hash>` and rebuilding. When several vitest
+ * workers invoke the same version at once, the ones reading it get
+ * `ENOENT ... /node_modules/prisma` or `could not determine executable to run`
+ * partway through. Warming the cache first is not enough, because the
+ * re-resolution can happen later.
+ *
+ * A directory we own has no such behaviour: installed once, never rewritten,
+ * safe for any number of concurrent readers.
+ */
+export default function installPrismaVersions() {
+    for (const version of versionsUnderTest()) {
+        const dir = prismaInstallDir(version)
+        const binary = path.join(dir, 'node_modules', 'prisma', 'build', 'index.js')
+
+        if (fs.existsSync(binary)) continue
+
+        fs.rmSync(dir, { recursive: true, force: true })
+        fs.mkdirSync(dir, { recursive: true })
+        fs.writeFileSync(
+            path.join(dir, 'package.json'),
+            JSON.stringify({ name: 'prisma-cli-under-test', private: true })
+        )
+
+        child_process.execSync(`bun add --exact prisma@${version}`, {
+            cwd: dir,
             stdio: 'ignore',
             env: { ...process.env, PRISMA_HIDE_UPDATE_MESSAGE: '1' },
         })
+
+        if (!fs.existsSync(binary)) {
+            throw new Error(
+                `Failed to install prisma@${version} for tests: expected ${binary}`
+            )
+        }
     }
 }

--- a/vitest.global-setup.mjs
+++ b/vitest.global-setup.mjs
@@ -30,7 +30,13 @@ export const prismaInstallDir = (version) =>
 export default function installPrismaVersions() {
     for (const version of versionsUnderTest()) {
         const dir = prismaInstallDir(version)
-        const binary = path.join(dir, 'node_modules', 'prisma', 'build', 'index.js')
+        const binary = path.join(
+            dir,
+            'node_modules',
+            'prisma',
+            'build',
+            'index.js'
+        )
 
         if (fs.existsSync(binary)) continue
 

--- a/vitest.setup.mjs
+++ b/vitest.setup.mjs
@@ -3,6 +3,7 @@ import child_process from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { prismaInstallDir } from './vitest.global-setup.mjs'
 
 const originalExecSync = child_process.execSync
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '.')
@@ -118,7 +119,16 @@ function runPrismaGenerate(command, options) {
         if (disableErdMatch?.[1]) {
             baseEnv.DISABLE_ERD = disableErdMatch[1]
         }
-        const runCmd = `bunx prisma@${version} generate --schema "${tmpSchemaPath}"`
+        // invoke the copy installed by the global setup rather than `bunx`,
+        // which shares one mutable cache directory across all workers
+        const prismaBin = path.join(
+            prismaInstallDir(version),
+            'node_modules',
+            'prisma',
+            'build',
+            'index.js'
+        )
+        const runCmd = `node "${prismaBin}" generate --schema "${tmpSchemaPath}"`
         originalExecSync(runCmd, {
             stdio: 'inherit',
             cwd: rootDir,


### PR DESCRIPTION
Fixes an intermittent test failure I introduced in #304. Test harness only — no shipped code changes, so it carries the `skip-changeset` label.

## Symptom

Runs fail with 11–16 files erroring, all reporting `Command failed: bunx prisma@<version> generate`. Each file passes in isolation. The real errors are inside bunx's cache:

```
.old-C2267BD5CF6CEA89/scripts/preinstall-entry.js
ENOENT ... /bunx-501-prisma@5.22.0/node_modules/prisma
error: could not determine executable to run for package prisma
```

## Cause

`bunx` keeps **one** cache directory per `package@version`, and re-resolves into it whenever it decides the contents are stale — moving the existing tree aside to `.old-<hash>` and rebuilding it. Every vitest worker invoking that version at that moment is reading a directory being rewritten underneath it.

The `globalSetup` I added in #304 warms each version once. That fixed the *first-population* race, which is the one that was failing then, but it cannot prevent a re-resolution later — so the flakiness stayed latent rather than fixed. This is the same bug, one layer deeper.

## Fix

Install each version into `tmp/prisma-cli/v<version>/` once, and invoke it by path:

```js
const prismaBin = path.join(prismaInstallDir(version), 'node_modules', 'prisma', 'build', 'index.js')
const runCmd = `node "${prismaBin}" generate --schema "${tmpSchemaPath}"`
```

A directory we own is written once and never rewritten, so concurrent readers are safe by construction rather than by timing. `tmp/` is already gitignored, and the install is skipped when the binary is already present, so repeat runs pay nothing.

## Verified

Deleted `tmp/prisma-cli` and ran the full suite from cold: **36/36 files, 57/57 tests** across all three Prisma versions, 24.9s. Previously 16 of 36 files failed on the same machine.