### PR TITLE
fix: stop warning about missing Chromium on Apple Silicon

### DIFF
--- a/.changeset/arm64-chromium-noise.md
+++ b/.changeset/arm64-chromium-noise.md
@@ -1,0 +1,13 @@
+---
+'prisma-erd-generator': patch
+---
+
+Stop warning about missing Chromium on Apple Silicon
+
+Every generate on a darwin/arm64 machine that rendered an image printed a stack trace followed by:
+
+> Prisma ERD Generator: Unable to find chromium path for you MacOS arm64 machine. Attempting to use the default at undefined.
+
+Three things were wrong with it. The `undefined` was real: the fallback path was assigned to a variable the puppeteer config object had already captured, so it never took effect — and the value it tried to assign was `/usr/bin/chromium-browser`, a Linux path, on macOS. The stack trace came from `console.error` in a `catch` that handles an entirely normal condition. And the check itself dates from when puppeteer shipped no arm64 Chromium; current puppeteer downloads its own, so the common case today is not having a system `chromium` at all, which meant nearly every Apple Silicon user saw this on every run.
+
+A system `chromium` on `PATH` is still preferred when present. Not having one is silent, and puppeteer uses the browser it manages. The ARM64 section of the README, which the message pointed at, has been updated to say the workaround is no longer needed.

--- a/README.md
+++ b/README.md
@@ -464,26 +464,21 @@ generator erd {
 
 Because this package relies on [mermaid js](https://mermaid.js.org/) and [puppeteer](https://pptr.dev/) issues often are opened that relate to those libraries causing issues between different versions of Node.js and your operating system. As a fallback, if you are one of those people not able to generate an ERD using this generator, try running the generator to output a markdown file `.md` first. Trying to generate a markdown file doesn't run into puppeteer to represent the contents of a mermaid drawing in a browser and often will succeed. This will help get you a functioning ERD while troubleshooting why puppeteer is not working for your machine. Please open an issue if you have any problems or suggestions.
 
-### 🔴 **ARM64 Users** 🔴
+### ARM64 users
 
-Puppeteer does not yet come shipped with a version of Chromium for arm64, so you will need to point to a Chromium executable on your system.
-More details on this issue can be found [here](https://github.com/puppeteer/puppeteer/issues/7740).
+**This is no longer necessary on macOS.** Puppeteer historically shipped no arm64 Chromium ([puppeteer#7740](https://github.com/puppeteer/puppeteer/issues/7740)), so Apple Silicon users had to supply their own. Current puppeteer downloads an arm64 build itself, and the generator needs no configuration.
 
-**MacOS Fix:**
+If you do have `chromium` on your `PATH`, the generator will still prefer it over the one puppeteer manages. Not having one is fine and is no longer reported as a problem.
 
-Install Chromium using Brew:
+<details>
+<summary>Using a system Chromium on macOS anyway</summary>
 
 ```bash
 brew install --cask --no-quarantine chromium
-```
-
-You should now see the path to your installed Chromium.
-
-```bash
 which chromium
 ```
 
-The generator will use this Chromium instead of the one provided by Puppeteer.
+</details>
 
 **Other Operating Systems:**
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -725,33 +725,37 @@ const mermaidRenderer: DiagramRenderer = {
             const tempPuppeteerConfigFile = path.resolve(
                 path.join(tmpDir, 'puppeteerConfig.json')
             )
-            let executablePath: string | undefined
             const puppeteerConfigJson: PuppeteerConfiguration & {
                 args?: string[]
             } = {
                 logLevel: debug ? 'warn' : 'error',
-                executablePath,
             }
-            // if MacOS M1/M2, provide your own path to chromium
+
+            // Puppeteer had no arm64 Chromium for a long time, so Apple
+            // Silicon users had to supply a system one. Puppeteer ships an
+            // arm64 build now, so this is only a courtesy for anyone who has
+            // `chromium` on PATH and would rather use it. Not finding one is
+            // the normal case and must stay silent: puppeteer then uses the
+            // browser it manages itself.
             if (os.platform() === 'darwin' && os.arch() === 'arm64') {
                 try {
-                    const executablePath = child_process
-                        .execSync('which chromium')
+                    const systemChromium = child_process
+                        .execSync('which chromium', {
+                            stdio: ['ignore', 'pipe', 'ignore'],
+                        })
                         .toString()
-                        .replace('\n', '')
-                    if (!executablePath) {
-                        throw new Error(
-                            'Could not find chromium executable. Refer to https://github.com/keonik/prisma-erd-generator#issues for next steps.'
+                        .trim()
+
+                    if (systemChromium) {
+                        puppeteerConfigJson.executablePath = systemChromium
+                        puppeteerConfigJson.args = ['--no-sandbox']
+                    }
+                } catch {
+                    if (debug) {
+                        console.log(
+                            'no `chromium` on PATH; using the browser puppeteer manages'
                         )
                     }
-                    puppeteerConfigJson.executablePath = executablePath
-                    puppeteerConfigJson.args = ['--no-sandbox']
-                } catch (error) {
-                    console.error(error)
-                    console.log(
-                        `\nPrisma ERD Generator: Unable to find chromium path for you MacOS arm64 machine. Attempting to use the default at ${executablePath}. To learn more visit https://github.com/keonik/prisma-erd-generator#-arm64-users-\n`
-                    )
-                    executablePath = '/usr/bin/chromium-browser'
                 }
             }
             fs.writeFileSync(


### PR DESCRIPTION
Found by smoke-testing the **published** 3.2.0 package as a consumer would, rather than from inside the repo where a chromium is always lying around.

## What every Apple Silicon user sees today

On every image render on darwin/arm64: a full stack trace, then

> `Prisma ERD Generator: Unable to find chromium path for you MacOS arm64 machine. Attempting to use the default at undefined.`

Three separate things are wrong here.

**1. The `undefined` is a real bug.** The outer variable is captured into the config object *before* it is ever assigned:

```ts
let executablePath: string | undefined
const puppeteerConfigJson = { logLevel, executablePath }   // captures undefined
// ...
} catch (error) {
    executablePath = '/usr/bin/chromium-browser'           // never reaches the object
}
```

So the fallback never took effect — and the value it tried to assign is `/usr/bin/chromium-browser`, a **Linux** path, on macOS. There is also a shadowed `const executablePath` inside the `try`, which is why the success path worked while the failure path silently didn't.

**2. It prints a stack trace for a normal condition.** `console.error(error)` in a `catch` that handles "you don't have brew's chromium".

**3. The check is obsolete.** It dates from when puppeteer shipped no arm64 Chromium ([puppeteer#7740](https://github.com/puppeteer/puppeteer/issues/7740)). Current puppeteer downloads its own arm64 build, so *not* having a system chromium is now the common case — which is why nearly every Apple Silicon user hits this on every run. It was always harmless (`JSON.stringify` drops the `undefined` key, so puppeteer fell through to its own browser), but it looks like a failure.

## Fix

A system `chromium` on `PATH` is still preferred when present — that path worked and still works. Not finding one is now silent, with a note only under `erdDebug`.

The README's ARM64 section, which the message linked to, told people to `brew install --cask chromium`. It now says that is no longer necessary, with the manual route kept in a collapsed block.

## Verified

Before: 1 occurrence of the warning per render. After: **0**.

Full suite across all four Prisma versions: **70 passed, 1 skipped**.