### PR TITLE
fix(test): give each worker its own tmp dir

### DIFF
--- a/.changeset/test-tmp-race.md
+++ b/.changeset/test-tmp-race.md
@@ -1,0 +1,13 @@
+---
+'prisma-erd-generator': patch
+---
+
+Fix a test-harness race that intermittently failed CI
+
+Every vitest worker wrote its temporary Prisma schemas under one shared `tmp/vitest` directory and deleted that whole tree in its own `process.on('exit')` handler. The first worker to finish therefore removed the schemas out from under the workers still running, which surfaced as:
+
+> Could not load `--schema` from provided path ...: file or directory not found
+
+It is timing-dependent, so it showed up as a single red cell in the matrix rather than a reproducible failure. Adding a fourth Prisma version to the matrix made runs longer and the overlap more likely.
+
+Each worker now owns `tmp/vitest/w<pid>`, and the shared `tmp/vitest` and `prisma/debug` directories are cleaned once from the global setup's teardown, after every worker has finished. Test harness only — no change to the published package.

--- a/vitest.global-setup.mjs
+++ b/vitest.global-setup.mjs
@@ -83,4 +83,18 @@ export default function installPrismaVersions() {
             )
         }
     }
+
+    // Runs once after every worker has finished. Cleaning these here rather
+    // than from each worker's exit handler is what keeps one worker from
+    // deleting directories another is still using.
+    return () => {
+        fs.rmSync(path.join(rootDir, 'tmp', 'vitest'), {
+            recursive: true,
+            force: true,
+        })
+        fs.rmSync(path.join(rootDir, 'prisma', 'debug'), {
+            recursive: true,
+            force: true,
+        })
+    }
 }

--- a/vitest.setup.mjs
+++ b/vitest.setup.mjs
@@ -7,7 +7,12 @@ import { prismaBinary, versionsUnderTest } from './vitest.global-setup.mjs'
 
 const originalExecSync = child_process.execSync
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '.')
-const tmpRoot = path.join(rootDir, 'tmp', 'vitest')
+// Per worker, not shared. Every worker used to write under one `tmp/vitest`
+// and delete the whole tree in its own exit handler, so the first worker to
+// finish pulled the schemas out from under the ones still running — surfacing
+// as `Could not load --schema ...: file or directory not found`. The shared
+// parent is cleaned once by the global setup's teardown instead.
+const tmpRoot = path.join(rootDir, 'tmp', 'vitest', `w${process.pid}`)
 
 if (process.env.VITEST_DEBUG_SETUP) {
     // eslint-disable-next-line no-console
@@ -155,9 +160,7 @@ vi.mock('node:child_process', async () => {
 })
 
 process.on('exit', () => {
+    // only this worker's own directory; `prisma/debug` is shared with the
+    // other workers and is cleaned by the global teardown
     fs.rmSync(tmpRoot, { recursive: true, force: true })
-    fs.rmSync(path.join(rootDir, 'prisma', 'debug'), {
-        recursive: true,
-        force: true,
-    })
 })


### PR DESCRIPTION
`main` has been red since #316. One job, and it moves around: `ubuntu-22.04 / node 22 / prisma 5.22.0` on the last two runs.

## The failure

```
FAIL __tests__/renderer.test.ts > renderer option end to end > writes DOT with no browser involved
Error: Could not load `--schema` from provided path
  `tmp/vitest/v5_22_0/__tests___tmp-renderer_dot/schema.prisma`: file or directory not found
```

The harness writes that file immediately before invoking Prisma, so "not found" means something deleted it in between.

## Cause

Every worker shared one temp root and cleaned it up on its own exit:

```js
const tmpRoot = path.join(rootDir, 'tmp', 'vitest')   // shared by all workers

process.on('exit', () => {
    fs.rmSync(tmpRoot, { recursive: true, force: true })   // wipes it for everyone
})
```

The first worker to finish deletes the tree out from under the workers still running. Whether that lands between another worker's write and Prisma's read is pure timing, which is why it presents as one arbitrary red cell rather than a reproducible failure — and why it only started firing regularly after #316 added a fourth Prisma version and made runs longer.

`prisma/debug` had the same bug in a milder form: one worker could delete it between another's `mkdirSync` and `writeFileSync`.

## Fix

- Each worker owns `tmp/vitest/w<pid>` and its exit handler removes only that.
- The shared `tmp/vitest` and `prisma/debug` are cleaned **once**, from the global setup's teardown, after every worker has finished.

## Verified

Three consecutive full runs, all four Prisma versions: **37/37 files, 70 passed, 1 skipped** each time. Confirmed both shared directories are gone afterwards, so the cleanup still does its job.

Test harness only — no change to the published package.