### PR TITLE
ci: point dependabot at the bun ecosystem, not npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  # `bun`, not `npm`. Dependabot has shipped a distinct bun ecosystem since
+  # 2025-02-13; declaring `npm` runs the npm updater, which looks for
+  # package-lock.json or yarn.lock, finds neither, and so edits package.json
+  # while leaving bun.lock untouched. Every version bump then failed CI on
+  # `bun install --frozen-lockfile` with "lockfile had changes, but lockfile is
+  # frozen" (#323, #325, #326). Range-widening PRs slipped through only because
+  # the locked version already satisfied the wider range (#324, #327).
+  - package-ecosystem: bun
     directory: '/'
     schedule:
       interval: monthly


### PR DESCRIPTION
Root cause of the three red dependabot PRs (#323, #325, #326).

## What was wrong

The bun migration never updated `.github/dependabot.yml`, which still declared:

```yaml
- package-ecosystem: npm
```

Dependabot has shipped a **separate `bun` ecosystem since 2025-02-13** ([GA changelog](https://github.blog/changelog/2025-02-13-dependabot-version-updates-now-support-the-bun-package-manager-ga/)). `npm` runs the npm updater, which looks for `package-lock.json` or `yarn.lock`. This repo has neither — only `bun.lock` — so it bumped `package.json` and left the lockfile alone. Every resulting PR failed at the install step:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

That is all three of #323, #325, #326 — and it would have been every future bump too.

The two that *passed* (#324, #327) are the tell: both only widen a range (`^11.9.0` → `^11.16.0`) that the already-locked version satisfies, so no lockfile change was needed and nothing was missing.

## After this

Dependabot will regenerate these PRs with `bun.lock` included. The two open majors are worth closing and letting it re-raise properly rather than hand-patching the lockfile:

- #325 `@changesets/cli` 2.x → 3.0.1
- #326 `@biomejs/biome` 1.9.4 → 2.5.11 (also needs a `biome migrate` for the v2 config schema — separate work)

## Caveat carried over from upstream

`bun.lock` updating is [known to silently no-op in npm-workspace layouts](https://github.com/dependabot/dependabot-core/issues/14223) (still open). This repo is a single package, so it is not affected — worth remembering if that ever changes.