### PR TITLE
docs(ci): record why the bun dependabot run currently fails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,20 @@ updates:
   # `bun install --frozen-lockfile` with "lockfile had changes, but lockfile is
   # frozen" (#323, #325, #326). Range-widening PRs slipped through only because
   # the locked version already satisfied the wider range (#324, #327).
+  #
+  # KNOWN BROKEN, deliberately left as-is: bun 1.4 writes
+  # `"lockfileVersion": 2`, and the bun bundled in Dependabot's updater image
+  # only parses version 1, so the monthly run currently errors with
+  #   Unsupported bun.lock 'lockfileVersion' 2 in /bun.lock
+  # That error IS the fix for dependabot-core#15848, where the old image
+  # silently rewrote the lockfile to v1 and changed resolutions with no
+  # warning; #15896 made it fail loudly instead. Real support is
+  # dependabot-core#16071, still open. Bun has no flag to emit a v1 lockfile,
+  # so there is no local workaround.
+  #
+  # Until #16071 ships this yields no dependency PRs. That is the intended
+  # trade: reverting to `npm` would restore the PRs but every one of them
+  # would arrive with a stale lockfile and fail CI.
   - package-ecosystem: bun
     directory: '/'
     schedule:


### PR DESCRIPTION
Comment-only. Keeps `package-ecosystem: bun` and writes down why the monthly run is red so it doesn't get "fixed" by reverting #329.

## The state

```
Dependabot::DependencyFileNotSupported
Unsupported bun.lock 'lockfileVersion' 2 in /bun.lock.
The bun version Dependabot runs supports up to 1.
```

bun 1.4 writes `"lockfileVersion": 2`; Dependabot's updater image bundles an older bun. There is no flag to make bun emit a v1 lockfile, so nothing can be done locally.

## Why this error is progress

It is the *fix* for [dependabot-core#15848](https://github.com/dependabot/dependabot-core/issues/15848), where the old image silently discarded a v2 lockfile, regenerated a v1, and changed resolutions with no warning. [#15896](https://github.com/dependabot/dependabot-core/issues/15896) made it reject loudly instead. Actual v2 support is [#16071](https://github.com/dependabot/dependabot-core/issues/16071) — still open, last updated 2026-08-28.

## The trade being accepted

No dependency PRs until #16071 ships. Reverting to `package-ecosystem: npm` would restore them, but every one would arrive with a stale `bun.lock` and fail `bun install --frozen-lockfile` — exactly the noise #329 cleared. A loud monthly failure beats a stream of red PRs.

`github-actions` updates are unaffected and still working.